### PR TITLE
Update Web Bluetooth flag name

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
                                         href="about://flags/#enable-web-bluetooth-new-permissions-backend">about://flags/#enable-web-bluetooth-new-permissions-backend</a> flag.
                                 </p>
                                 <p>
-                                    On Linux only, turn on Web Bluetooth by enabling with the experimental <a
+                                    On Linux only, enable the experimental <a
                                         href="about://flags/#enable-experimental-web-platform-features">about://flags/#enable-experimental-web-platform-features</a>
                                     flag. However be careful as it would be risky to browse the web whith this flag turned
                                     on as it enables many other experimental web platform features. Starting with Chromium

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
                                 <p>
                                     Then enable the following two flags:<br>
                                     <a
-                                        href="chrome://flags/#enable-experimental-web-platform-features">chrome://flags/#enable-experimental-web-platform-features</a><br>
+                                        href="chrome://flags/#enable-web-bluetooth">chrome://flags/#enable-web-bluetooth</a> (for Linux only)<br>
                                     <a
                                         href="chrome://flags/#enable-web-bluetooth-new-permissions-backend">chrome://flags/#enable-web-bluetooth-new-permissions-backend</a>
                                 </p>

--- a/index.html
+++ b/index.html
@@ -63,13 +63,17 @@
                                     Web Bluetooth is currently only supported in Chromium-based browsers.
                                 </p>
                                 <p>
-                                    To get the best experience, enable the following flags:<br>
-                                    <a
-                                        href="about://flags/#enable-web-bluetooth-new-permissions-backend">about://flags/#enable-web-bluetooth-new-permissions-backend</a><br>
-                                    <a
-                                        href="about://flags/#enable-web-bluetooth">about://flags/#enable-web-bluetooth</a> or
-                                    <a
-                                        href="about://flags/#enable-experimental-web-platform-features">about://flags/#enable-experimental-web-platform-features</a> (on Linux only)
+                                    To get the best experience, enable the experimental <a
+                                        href="about://flags/#enable-web-bluetooth-new-permissions-backend">about://flags/#enable-web-bluetooth-new-permissions-backend</a> flag.
+                                </p>
+                                <p>
+                                    On Linux only, turn on Web Bluetooth by enabling with the experimental <a
+                                        href="about://flags/#enable-experimental-web-platform-features">about://flags/#enable-experimental-web-platform-features</a>
+                                    flag. However be careful as it would be risky to browse the web whith this flag turned
+                                    on as it enables many other experimental web platform features. Starting with Chromium
+                                    version 100, enable the <a
+                                        href="about://flags/#enable-web-bluetooth">about://flags/#enable-web-bluetooth</a>
+                                    safer flag instead.
                                 </p>
                             </div>
                         </section>


### PR DESCRIPTION
I've just added a flag to enable the Web Bluetooth API on Linux at `chrome://flags/#enable-web-bluetooth`

See https://twitter.com/quicksave2k/status/1489150418319990785

@makermelissa 