### PR TITLE
Reference error and error in removing .py from the path 

### DIFF
--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,0 +1,3 @@
+// place to put global constants
+export const MODE_EDITOR = 1;
+export const MODE_SERIAL = 2;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -9,6 +9,7 @@ import {USBWorkflow} from './workflows/usb.js';
 import {CONNTYPE, CHAR_CTRL_D, isValidBackend, getBackendWorkflow, getWorkflowBackendName} from './workflows/workflow.js';
 import {ButtonValueDialog, MessageModal} from './common/dialogs.js';
 import {sleep, isLocal, switchUrl, getUrlParam} from './common/utilities.js';
+import {MODE_EDITOR, MODE_SERIAL} from './constants.js';
 
 var terminal;
 var fitter;
@@ -32,9 +33,6 @@ const btnSaveAs = document.querySelectorAll('.btn-save-as');
 const btnSaveRun = document.querySelectorAll('.btn-save-run');
 const btnInfo = document.getElementById('btn-info');
 const terminalTitle = document.getElementById('terminal-title');
-
-const MODE_EDITOR = 1;
-const MODE_SERIAL = 2;
 
 const messageDialog = new MessageModal("message");
 const connectionType = new ButtonValueDialog("connection-type");
@@ -266,6 +264,7 @@ async function loadWorkflow(workflowType = null) {
                 loadEditorContentsFunc: loadEditorContents,
                 showMessageFunc: showMessage,
                 currentFilename: currentFilename,
+                changeModeFunc: changeMode,
             });
         } else {
             console.log("Reload workflow");
@@ -532,8 +531,3 @@ document.addEventListener('DOMContentLoaded', async (event) => {
         await checkConnected();
     }
 });
-
-export {
-    MODE_SERIAL,
-    changeMode
-}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -532,3 +532,8 @@ document.addEventListener('DOMContentLoaded', async (event) => {
         await checkConnected();
     }
 });
+
+export {
+    MODE_SERIAL,
+    changeMode
+}

--- a/assets/js/workflows/workflow.js
+++ b/assets/js/workflows/workflow.js
@@ -2,7 +2,7 @@ import {sleep, timeout, regexEscape} from '../common/utilities.js';
 import {FileHelper} from '../common/file.js';
 import {UnsavedDialog} from '../common/dialogs.js';
 import {FileDialog, FILE_DIALOG_OPEN, FILE_DIALOG_SAVE} from '../common/file_dialog.js';
-
+import {changeMode, MODE_SERIAL} from '../script.js';
 /*
  * This class will encapsulate all of the common workflow-related functions
  */
@@ -215,7 +215,7 @@ class Workflow {
             console.log("Extension not py, twas " + String(extension).toLowerCase());
             return false;
         }
-        path = path.substr(1, path.length - 4);
+        path = path.slice(0, -3);
         path = path.replace(/\//g, ".");
 
         await changeMode(MODE_SERIAL);

--- a/assets/js/workflows/workflow.js
+++ b/assets/js/workflows/workflow.js
@@ -2,7 +2,7 @@ import {sleep, timeout, regexEscape} from '../common/utilities.js';
 import {FileHelper} from '../common/file.js';
 import {UnsavedDialog} from '../common/dialogs.js';
 import {FileDialog, FILE_DIALOG_OPEN, FILE_DIALOG_SAVE} from '../common/file_dialog.js';
-import {changeMode, MODE_SERIAL} from '../script.js';
+import { MODE_SERIAL } from '../constants.js';
 /*
  * This class will encapsulate all of the common workflow-related functions
  */
@@ -75,6 +75,7 @@ class Workflow {
             this.terminalTitle = params.terminalTitle;
         }
         this.currentFilename = params.currentFilename;
+        this._changeMode = params.changeModeFunc;
     }
 
     async initFileClient(fileClient) {
@@ -218,7 +219,7 @@ class Workflow {
         path = path.slice(0, -3);
         path = path.replace(/\//g, ".");
 
-        await changeMode(MODE_SERIAL);
+        await this._changeMode(MODE_SERIAL);
         await this.serialTransmit(CHAR_CTRL_C + "import " + path + CHAR_CRLF);
     }
 


### PR DESCRIPTION
Hi I was trying out the USB workflow, with  Save + Run. I got a ref error in the console trying to get changeMode from the script.js:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/5277142/198901707-20c1479e-1ee5-445d-a591-9ff30457ca21.png">
So I've added an export for changeMode and MODE_SERIAL (not sure if its good, but snowpack seems to sort it out).
Then when trying to run a file "test.py", it would try to run "import es" instead of "import test". So I think the extension substring is a typo. The following seemed to work to remove .py:
```
path.slice(0, -3)
```
 
Hope this helps a little bit. It's going to be nice to have a quick way to test code from just the browser.

FYI: I don't 100% understand the Save + Run for USB. It doesn't save the files to the device. I suppose it's related to #15, I wonder if we could also add a RUN only command that will reset, then paste the code in the editor to the REPL to run tests quickly.
