### PR TITLE
hide all other steps if no web serial support is available

### DIFF
--- a/assets/js/workflows/usb.js
+++ b/assets/js/workflows/usb.js
@@ -174,6 +174,9 @@ class USBWorkflow extends Workflow {
             }
             this._connectionStep(1);
         } else {
+            modal.querySelectorAll('.step:not(:first-of-type)').forEach((stepItem) => {
+                stepItem.classList.add("hidden");
+            });
             this._connectionStep(0);
         }
 

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
             <section class="step">
                 <div class="step-number"></div>
                 <div class="step-content">
-                    <h1>Set Up Web Serial</h1>
+                    <h1>Web Serial not available!</h1>
                     <p>Web Serial is currently only supported in Chromium-based browsers.</p>
                     <p>For versions of Google Chrome between versions 78-89, Web Serial needs to manually be enabled. On recent browsers, this feature is enabled by default. If you are on an older version of the browser,
                         you may be able to enable Web Serial with the


### PR DESCRIPTION
The previous behaviour was confusing to users if the steps and buttons are visible but greyed out.

**Screenshot of old behaviour:**
<img width="804" alt="Screenshot 2023-03-29 at 16 48 06" src="https://user-images.githubusercontent.com/114300/228577516-5d1bee0b-6f44-464e-814c-9418181b2f68.png">

**Screenshot of new improved behaviour:**
<img width="808" alt="Screenshot 2023-03-29 at 16 49 09" src="https://user-images.githubusercontent.com/114300/228577684-c84d52e6-4422-41d2-b565-154265221667.png">
