### PR TITLE
hide all other steps if no web bluetooth support is available

### DIFF
--- a/assets/js/workflows/ble.js
+++ b/assets/js/workflows/ble.js
@@ -67,6 +67,9 @@ class BLEWorkflow extends Workflow {
             const devices = await navigator.bluetooth.getDevices();
             this.connectionStep(devices.length > 0 ? 2 : 1);
         } else {
+            modal.querySelectorAll('.step:not(:first-of-type)').forEach((stepItem) => {
+                stepItem.classList.add("hidden");
+            });
             this.connectionStep(0);
         }
 
@@ -259,11 +262,10 @@ class BLEWorkflow extends Workflow {
 
     async available() {
         if (!('bluetooth' in navigator)) {
-            return Error("Bluetooth not supported on this browser");
+            return Error("Web Bluetooth is not enabled in this browser");
         } else if (!(await navigator.bluetooth.getAvailability())) {
-            return Error("No bluetooth adapter founnd");
+            return Error("No bluetooth adapter found");
         }
-
         return true;
     }
 

--- a/index.html
+++ b/index.html
@@ -189,12 +189,10 @@
             <section class="step">
                 <div class="step-number"></div>
                 <div class="step-content">
-                    <h1>Set Up Web Bluetooth</h1>
+                    <h1>Web Bluetooth not available!</h1>
                     <p>Web Bluetooth is currently only supported in Chromium-based browsers.</p>
-                    <p>To get the best experience, enable the experimental <a
-                            href="about://flags/#enable-web-bluetooth-new-permissions-backend">about://flags/#enable-web-bluetooth-new-permissions-backend</a>
-                        flag.</p>
-                    <p>On Linux only, enable the experimental <a
+
+                    <p>On Linux only with older versions of Google Chrome, enable the experimental <a
                             href="about://flags/#enable-experimental-web-platform-features">about://flags/#enable-experimental-web-platform-features</a>
                         flag. However be careful as it would be risky to browse the web whith this flag turned
                         on as it enables many other experimental web platform features. Starting with Chromium


### PR DESCRIPTION
The previous behaviour was confusing to users if the steps and buttons are visible but greyed out.

Also fixing a typo.

same as #68 but for bluetooth.