### PR TITLE
use same layout for editor-bar and serial-bar

### DIFF
--- a/assets/sass/layout/_header.scss
+++ b/assets/sass/layout/_header.scss
@@ -129,7 +129,7 @@
     }
 }
 
-#editor-bar {
+#editor-bar, #serial-bar {
     display: flex;
 }
 
@@ -138,7 +138,7 @@
         display: none !important;
     }
 
-    #editor-bar {
+    #editor-bar, #serial-bar {
         display: none !important;
     }
 }

--- a/index.html
+++ b/index.html
@@ -90,13 +90,17 @@
             </div>
         </div>
         <div id="serial-page" class="wrapper">
-            <div class="container" id="serial-bar">
-                <button class="purple-button" id="btn-restart">Restart<i class="fa-solid fa-redo"></i></button>
-                <div id="terminal-title"></div>
+            <div class="container">
+                <div id="serial-bar">
+                    <button class="purple-button btn-restart">Restart<i class="fa-solid fa-redo"></i></button>
+                    <div id="terminal-title"></div>
+                </div>
             </div>
-            <div class="terminal-container">
-                <div class="container">
-                    <div id="terminal"></div>
+            <div>
+                <div class="terminal-container">
+                    <div class="container">
+                        <div id="terminal"></div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Previously, one used flexbox and the other not, causing a small pixel offset when switching modes.