### PR TITLE
address all buttons with classes instead of mix out of class+id

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -22,16 +22,16 @@ workflows[CONNTYPE.Ble] = new BLEWorkflow();
 workflows[CONNTYPE.Web] = new WebWorkflow();
 workflows[CONNTYPE.Usb] = new USBWorkflow();
 
-const btnModeEditor = document.getElementById('btn-mode-editor');
-const btnModeSerial = document.getElementById('btn-mode-serial');
-const btnRestart = document.getElementById('btn-restart');
+const btnModeEditor = document.querySelector('.btn-mode-editor');
+const btnModeSerial = document.querySelector('.btn-mode-serial');
+const btnRestart = document.querySelector('.btn-restart');
 const mainContent = document.getElementById('main-content');
 const btnConnect = document.querySelectorAll('.btn-connect');
 const btnNew = document.querySelectorAll('.btn-new');
 const btnOpen = document.querySelectorAll('.btn-open');
 const btnSaveAs = document.querySelectorAll('.btn-save-as');
 const btnSaveRun = document.querySelectorAll('.btn-save-run');
-const btnInfo = document.getElementById('btn-info');
+const btnInfo = document.querySelector('.btn-info');
 const terminalTitle = document.getElementById('terminal-title');
 
 const messageDialog = new MessageModal("message");

--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -80,8 +80,8 @@ h5 {
 }
 
 .purple-button.inverted,
-.mode-editor #btn-mode-serial,
-.mode-serial #btn-mode-editor {
+.mode-editor .btn-mode-serial,
+.mode-serial .btn-mode-editor {
     color: $purple;
     background-color: $gray;
 

--- a/index.html
+++ b/index.html
@@ -101,10 +101,10 @@
             </div>
         </div>
         <div class="container" id="footer-bar">
-            <button class="mode-button purple-button" id="btn-mode-editor">Editor</button>
-            <button class="mode-button purple-button active" id="btn-mode-serial">Serial</button>
+            <button class="mode-button purple-button btn-mode-editor">Editor</button>
+            <button class="mode-button purple-button active btn-mode-serial">Serial</button>
             <div class="spacer"></div>
-            <button class="purple-button" id="btn-info" disabled>Info<i class="fa-solid fa-info-circle"></i></button>
+            <button class="purple-button btn-info" disabled>Info<i class="fa-solid fa-info-circle"></i></button>
         </div>
     </div>
 


### PR DESCRIPTION
address all buttons with classes instead of mix out of class+id

No behaviour or UI change - just a bit of code hygiene to have the same conventions across all buttons.