### PR TITLE
fix incomplete serial data due to REPL partial parsing and mutating of data field

### DIFF
--- a/assets/js/workflows/workflow.js
+++ b/assets/js/workflows/workflow.js
@@ -114,9 +114,10 @@ class Workflow {
     }
 
     async onSerialReceive(e) {
-        await this.repl.onSerialReceive(e);
-
         this.writeToTerminal(e.data);
+        // TODO: the current REPL implementation mutates the data field for partial token parsing,
+        // so invoke it after (!) writing to the terminal.
+        await this.repl.onSerialReceive(e);
     }
 
     connectionStatus(partialConnectionsAllowed = false) {
@@ -189,7 +190,6 @@ class Workflow {
         if (path == "/code.py") {
             await this.repl.softRestart();
         } else {
-
             let extension = path.split('.').pop();
             if (extension === null) {
                 console.log("Extension not found");


### PR DESCRIPTION
caused by https://github.com/adafruit/circuitpython-repl-js/blob/main/repl.js#L108

Not sure if this should be addressed in this library directly or worked around here instead.
I tried updating web-editor to use the latest v1.2.1 of repl.js, but this just caused different problems and new/unexpected behaviour for me.

For now, this workaround seems like the most reasonable fix, also given that it also works for CircuitPython 7.x, while the repl.js at least states in the readme it only supports v8 at this time.