### PR TITLE
debug log: cleanup lines and fix broken indendation

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -318,7 +318,8 @@ async function changeMode(mode) {
 }
 
 async function debugLog(msg) {
-    terminal.write(`\x1b[93m${msg}\x1b[m\n`);
+    terminal.writeln(''); // get a fresh line without any prior content (a '>>>' prompt might be there without newline)
+    terminal.writeln(`\x1b[93m${msg}\x1b[0m`);
 }
 
 function updateUIConnected(isConnected) {


### PR DESCRIPTION
The current behaviour of debug log messages caused some not so pretty output.

If the current serial output is a partial line, i.e., a `>>>` prompt without newline at the end, the debug line would be in the same line. This PR now always puts it on a fresh line by itself.

Previously, there was a large horizontal indentation after the log line, now the new line starts at column 0 as expected.

**Before:**
```
>>> Foo**connected**
         <some space here>
```

**After:**
```
>>> Foo
**connected**
<curser column 0>
```