### PR TITLE
auto-render web links in terminal as clickable hyperlinks

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -466,8 +466,12 @@ function setupXterm() {
             cursor: '#ddd',
         }
     });
+
     fitter = new FitAddon.FitAddon();
     terminal.loadAddon(fitter);
+
+    terminal.loadAddon(new WebLinksAddon.WebLinksAddon());
+
     terminal.open(document.getElementById('terminal'));
     terminal.onData((data) => {
         workflow.serialTransmit(data);

--- a/index.html
+++ b/index.html
@@ -333,6 +333,7 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/xterm@5.1.0/lib/xterm.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.6.0/lib/xterm-addon-fit.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.8.0/lib/xterm-addon-web-links.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"
         integrity="sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==" crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
This PR makes everything that looks like a URL in the terminal output to be clickable in the browser which then opens the link in a new tab. No visual change except when you mouse-hover over the URL itself.