### PR TITLE
terminal auto-resizing and fitting

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -313,8 +313,22 @@ async function changeMode(mode) {
         mainContent.classList.add("mode-editor");
     } else if (mode == MODE_SERIAL) {
         mainContent.classList.add("mode-serial");
-        fitter.fit();
+        refitTerminal();
     }
+}
+
+function refitTerminal() {
+    // Re-fitting the terminal requires a full re-layout of the DOM which can be tricky to time right.
+    // see https://www.macarthur.me/posts/when-dom-updates-appear-to-be-asynchronous
+    window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+                if (fitter) {
+                    fitter.fit();
+                }
+            });
+        });
+    });
 }
 
 async function debugLog(msg) {
@@ -345,9 +359,7 @@ function updateUIConnected(isConnected) {
 function fixViewportHeight() {
     let vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
-    if (fitter) {
-        fitter.fit();
-    }
+    refitTerminal();
 }
 
 window.onbeforeunload = () => {

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/xterm@5.1.0/lib/xterm.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.6.0/lib/xterm-addon-fit.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.7.0/lib/xterm-addon-fit.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"
         integrity="sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==" crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
Previously, the first time one changes from editor to terminal mode, the terminal itself did not resize as the DOM has not updated yet. If one then resizes the whole window, it will trigger correctly. Also if you cycle back to editor-terminal-editor-terminal it works.

This PR fixes this by waiting for the DOM to update and render correctly.