### PR TITLE
add MIT license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2023 Adafruit Industries and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ This way requires installing mkcert, but it's much easier to switch back and for
 1. Install [mkcert](https://github.com/FiloSottile/mkcert) on your system
 2. Generate the certificates by running: mkcert -install && mkcert -key-file snowpack.key -cert-file snowpack.crt localhost
 3. Start snowpack in secure mode by --secure to the command: npx snowpack dev --secure
+
+## License
+
+This project is made available under the MIT License. For more details, see the LICENSE file in the repository.


### PR DESCRIPTION
The current repository is missing license information.

Based on the majority of other repositories under the circuitpython GitHub org, and Adafruit org, and personal preference, I chose the MIT license.

I have no affiliation with Adafruit, so I'm not sure what the correct license holder at this point should be.
@makermelissa please let me know what the best approach here would be - pinging [all existing contributors](https://github.com/circuitpython/web-editor/graphs/contributors) to get their sign-off?