### PR TITLE
side-by-side layout for editor+serial

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,9 @@
                         </a>
                     </div>
                     <div class="get-started">
+                        <a class="github-repo" href="https://github.com/circuitpython/web-editor">
+                            <i class="fa-brands fa-github"></i>
+                        </a>
                         <button class="btn-connect">Connect</button>
                     </div>
                 </nav>

--- a/index.html
+++ b/index.html
@@ -12,15 +12,42 @@
 <body>
     <div id="blackout" class="body-blackout"></div>
     <div id="clickblock" class="body-blackout no-overlay"></div>
-    <header id="site-header">
-        <div class="wrapper">
-            <div class="content container">
+
+    <div class="layout">
+        <header id="site-header">
+            <div class="wrapper">
+                <div class="content container">
+                    <nav class="site-brand">
+                        <div class="site-logo">
+                            <a href="https://code.circuitpython.org/">
+                                <img alt="CircuitPython Logo" height="50"
+                                    src="/images/logo.png"
+                                    srcset="/images/logo.png 1x,
+                                            /images/logo@2x.png 2x,
+                                            /images/logo@3x.png 3x" >
+                            </a>
+                        </div>
+                        <div class="get-started">
+                            <a class="github-repo" href="https://github.com/circuitpython/web-editor">
+                                <i class="fa-brands fa-github"></i>
+                            </a>
+                            <button class="btn-connect">Connect</button>
+                        </div>
+                    </nav>
+                </div>
+            </div>
+            <div class="bottom-bar"></div>
+        </header>
+        <header id="mobile-header">
+            <div class="header-contents">
                 <nav class="site-brand">
                     <div class="site-logo">
                         <a href="https://code.circuitpython.org/">
-                            <img src="/images/logo.png" srcset="/images/logo.png 1x,
-                                    /images/logo@2x.png 2x,
-                                    /images/logo@3x.png 3x" alt="CircuitPython Logo" height="60" width="136">
+                            <img alt="CircuitPython Logo" height="40"
+                                 src="/images/logo.png"
+                                 srcset="/images/logo.png 1x,
+                                         /images/logo@2x.png 2x,
+                                         /images/logo@3x.png 3x" >
                         </a>
                     </div>
                     <div class="get-started">
@@ -28,29 +55,18 @@
                     </div>
                 </nav>
             </div>
-        </div>
-        <div class="bottom-bar"></div>
-    </header>
-    <header id="mobile-header">
-        <div class="header-contents">
-            <nav class="site-brand">
-                <div class="site-logo">
-                    <a href="https://code.circuitpython.org/">
-                        <img src="/images/logo.png" srcset="/images/logo.png 1x,
-                                    /images/logo@2x.png 2x,
-                                    /images/logo@3x.png 3x" alt="CircuitPython Logo" height="40" width="91">
-                    </a>
+            <div class="bottom-bar"></div>
+        </header>
+        <div id="main-content">
+            <div id="editor-page" class="active">
+                <div id="editor-bar">
+                    <button class="purple-button btn-new">New<i class="fa-solid fa-plus"></i></button>
+                    <button class="purple-button btn-open">Open<i class="fa-solid fa-folder-open"></i></button>
+                    <button class="purple-button btn-save">Save<i class="fa-solid fa-floppy-disk"></i></button>
+                    <button class="purple-button btn-save-as">Save As<i class="fa-solid fa-download"></i></button>
+                    <div class="file-path"></div>
+                    <button class="purple-button btn-save-run">Save + Run<i class="fa-solid fa-play"></i></button>
                 </div>
-                <div class="get-started">
-                    <button class="btn-connect">Connect</button>
-                </div>
-            </nav>
-        </div>
-        <div class="bottom-bar"></div>
-    </header>
-    <div class="mode-editor" id="main-content">
-        <div id="editor-page" class="wrapper">
-            <div class="container">
                 <div id="mobile-editor-bar">
                     <div id="mobile-menu">
                         <div class="menu-toggle">
@@ -72,42 +88,21 @@
                         </ul>
                     </nav>
                 </div>
-                <div id="editor-bar">
-                    <button class="purple-button btn-new">New<i class="fa-solid fa-plus"></i></button>
-                    <button class="purple-button btn-open">Open<i class="fa-solid fa-folder-open"></i></button>
-                    <button class="purple-button btn-save">Save<i class="fa-solid fa-floppy-disk"></i></button>
-                    <button class="purple-button btn-save-as">Save As<i class="fa-solid fa-download"></i></button>
-                    <div class="file-path"></div>
-                    <button class="purple-button btn-save-run">Save + Run<i class="fa-solid fa-play"></i></button>
-                </div>
+                <div id="editor"></div>
             </div>
-            <div>
-                <div class="editor-container">
-                    <div class="container">
-                        <div id="editor"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div id="serial-page" class="wrapper">
-            <div class="container">
+            <div id="page-separator" class=""></div>
+            <div id="serial-page" class="">
                 <div id="serial-bar">
                     <button class="purple-button btn-restart">Restart<i class="fa-solid fa-redo"></i></button>
                     <button class="purple-button btn-clear">Clear<i class="fa-solid fa-broom"></i></button>
                     <div id="terminal-title"></div>
                 </div>
-            </div>
-            <div>
-                <div class="terminal-container">
-                    <div class="container">
-                        <div id="terminal"></div>
-                    </div>
-                </div>
+                <div id="terminal"></div>
             </div>
         </div>
-        <div class="container" id="footer-bar">
-            <button class="mode-button purple-button btn-mode-editor">Editor</button>
-            <button class="mode-button purple-button active btn-mode-serial">Serial</button>
+        <div id="footer-bar">
+            <button class="mode-button btn-mode-editor active">Editor</button>
+            <button class="mode-button btn-mode-serial">Serial</button>
             <div class="spacer"></div>
             <button class="purple-button btn-info" disabled>Info<i class="fa-solid fa-info-circle"></i></button>
         </div>

--- a/index.html
+++ b/index.html
@@ -101,8 +101,8 @@
             </div>
         </div>
         <div id="footer-bar">
-            <button class="mode-button btn-mode-editor active">Editor</button>
-            <button class="mode-button btn-mode-serial">Serial</button>
+            <button id="btn-mode-editor" class="mode-button active">Editor</button>
+            <button id="btn-mode-serial" class="mode-button">Serial</button>
             <div class="spacer"></div>
             <button class="purple-button btn-info" disabled>Info<i class="fa-solid fa-info-circle"></i></button>
         </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,4 @@
 // place to put global constants
-export const MODE_EDITOR = 1;
-export const MODE_SERIAL = 2;
 
 export const CONNTYPE = {
     None: 1,

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,0 +1,133 @@
+import state from './state.js'
+
+const btnModeEditor = document.getElementById('btn-mode-editor');
+const btnModeSerial = document.getElementById('btn-mode-serial');
+
+export const mainContent = document.getElementById('main-content');
+const editorPage = document.getElementById('editor-page');
+const serialPage = document.getElementById('serial-page');
+const pageSeparator = document.getElementById('page-separator');
+
+btnModeEditor.addEventListener('click', async function (e) {
+    if (btnModeEditor.classList.contains('active') && !btnModeSerial.classList.contains('active')) {
+        // this would cause both editor & serial pages to disappear
+        return;
+    }
+    btnModeEditor.classList.toggle('active');
+    editorPage.classList.toggle('active')
+    updatePageLayout(true, false);
+});
+
+btnModeSerial.addEventListener('click', async function (e) {
+    if (btnModeSerial.classList.contains('active') && !btnModeEditor.classList.contains('active')) {
+        // this would cause both editor & serial pages to disappear
+        return;
+    }
+    btnModeSerial.classList.toggle('active');
+    serialPage.classList.toggle('active')
+    updatePageLayout(false, true);
+});
+
+function updatePageLayout(editor = false, serial = false) {
+    if (editorPage.classList.contains('active') && serialPage.classList.contains('active')) {
+        pageSeparator.classList.add('active');
+    } else {
+        pageSeparator.classList.remove('active');
+        editorPage.style.width = null;
+        editorPage.style.flex = null;
+        serialPage.style.width = null;
+        serialPage.style.flex = null;
+        return;
+    }
+
+    if (mainContent.offsetWidth < 768) {
+        if (editor) {
+            btnModeSerial.classList.remove('active');
+            serialPage.classList.remove('active');
+        } else if (serial) {
+            btnModeEditor.classList.remove('active');
+            editorPage.classList.remove('active');
+        }
+        pageSeparator.classList.remove('active');
+    } else {
+        let w = mainContent.offsetWidth;
+        let s = pageSeparator.offsetWidth;
+        editorPage.style.width = ((w - s) / 2) + 'px';
+        editorPage.style.flex = '0 0 auto';
+        serialPage.style.width = ((w - s) / 2) + 'px';
+        serialPage.style.flex = '0 0 auto';
+    }
+
+    if (serial) {
+        refitTerminal();
+    }
+}
+
+export function showEditor() {
+    btnModeEditor.classList.add('active');
+    editorPage.classList.add('active');
+    updatePageLayout(true, false);
+}
+
+export function showSerial() {
+    btnModeSerial.classList.add('active');
+    serialPage.classList.add('active');
+    updatePageLayout(false, true);
+}
+
+function refitTerminal() {
+    // Re-fitting the terminal requires a full re-layout of the DOM which can be tricky to time right.
+    // see https://www.macarthur.me/posts/when-dom-updates-appear-to-be-asynchronous
+    window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+                if (state.fitter) {
+                    state.fitter.fit();
+                }
+            });
+        });
+    });
+}
+
+function fixViewportHeight() {
+    let vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+    refitTerminal();
+}
+fixViewportHeight();
+window.addEventListener("resize", fixViewportHeight);
+
+function resize(e) {
+    const w = mainContent.offsetWidth;
+    const gap = pageSeparator.offsetWidth;
+    const ratio = e.clientX / w;
+    const hidingThreshold = 0.1;
+    const minimumThreshold = 0.2;
+    if (ratio < hidingThreshold) {
+        editorPage.classList.remove('active');
+        btnModeEditor.classList.remove('active');
+        updatePageLayout();
+        stopResize();
+        return;
+    } else if (ratio > 1 - hidingThreshold) {
+        serialPage.classList.remove('active');
+        btnModeSerial.classList.remove('active');
+        updatePageLayout();
+        stopResize();
+        return;
+    } else if (ratio < minimumThreshold || ratio > 1 - minimumThreshold) {
+        return;
+    }
+    editorPage.style.width = (e.clientX - gap / 2) + 'px';
+    serialPage.style.width = (w - e.clientX - gap / 2) + 'px';
+}
+
+function stopResize(e) {
+    window.removeEventListener('mousemove', resize, false);
+    window.removeEventListener('mouseup', stopResize, false);
+}
+
+pageSeparator.addEventListener('mousedown', async function (e) {
+    window.addEventListener('mousemove', resize, false);
+    window.addEventListener('mouseup', stopResize, false);
+});

--- a/js/script.js
+++ b/js/script.js
@@ -15,7 +15,7 @@ import { WebWorkflow } from './workflows/web.js';
 import { isValidBackend, getBackendWorkflow, getWorkflowBackendName } from './workflows/workflow.js';
 import { ButtonValueDialog, MessageModal } from './common/dialogs.js';
 import { isLocal, switchUrl, getUrlParam } from './common/utilities.js';
-import { MODE_EDITOR, MODE_SERIAL, CONNTYPE } from './constants.js';
+import { CONNTYPE } from './constants.js';
 
 var terminal;
 var fitter;
@@ -28,11 +28,8 @@ workflows[CONNTYPE.Ble] = new BLEWorkflow();
 workflows[CONNTYPE.Usb] = new USBWorkflow();
 workflows[CONNTYPE.Web] = new WebWorkflow();
 
-const btnModeEditor = document.querySelector('.btn-mode-editor');
-const btnModeSerial = document.querySelector('.btn-mode-serial');
 const btnRestart = document.querySelector('.btn-restart');
 const btnClear = document.querySelector('.btn-clear');
-const mainContent = document.getElementById('main-content');
 const btnConnect = document.querySelectorAll('.btn-connect');
 const btnNew = document.querySelectorAll('.btn-new');
 const btnOpen = document.querySelectorAll('.btn-open');
@@ -144,15 +141,6 @@ btnRestart.addEventListener('click', async function(e) {
 // Clear Button
 btnClear.addEventListener('click', async function(e) {
     terminal.clear();
-});
-
-// Mode Buttons
-btnModeEditor.addEventListener('click', async function(e) {
-    await changeMode(MODE_EDITOR);
-});
-
-btnModeSerial.addEventListener('click', async function(e) {
-    await changeMode(MODE_SERIAL);
 });
 
 btnInfo.addEventListener('click', async function(e) {
@@ -316,7 +304,7 @@ async function loadWorkflow(workflowType = null) {
                 loadEditorContentsFunc: loadEditorContents,
                 showMessageFunc: showMessage,
                 currentFilename: currentFilename,
-                changeModeFunc: changeMode,
+                showSerialFunc: showSerial,
             });
         } else {
             console.log("Reload workflow");
@@ -353,32 +341,6 @@ async function showMessage(message) {
     return await messageDialog.open(message);
 }
 
-async function changeMode(mode) {
-    if (mode > 0) {
-        mainContent.classList.remove("mode-editor", "mode-serial");
-    }
-    if (mode == MODE_EDITOR) {
-        mainContent.classList.add("mode-editor");
-    } else if (mode == MODE_SERIAL) {
-        mainContent.classList.add("mode-serial");
-        refitTerminal();
-    }
-}
-
-function refitTerminal() {
-    // Re-fitting the terminal requires a full re-layout of the DOM which can be tricky to time right.
-    // see https://www.macarthur.me/posts/when-dom-updates-appear-to-be-asynchronous
-    window.requestAnimationFrame(() => {
-        window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => {
-                if (fitter) {
-                    fitter.fit();
-                }
-            });
-        });
-    });
-}
-
 async function debugLog(msg) {
     terminal.writeln(''); // get a fresh line without any prior content (a '>>>' prompt might be there without newline)
     terminal.writeln(`\x1b[93m${msg}\x1b[0m`);
@@ -404,20 +366,11 @@ function updateUIConnected(isConnected) {
     }
 }
 
-function fixViewportHeight() {
-    let vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty('--vh', `${vh}px`);
-    refitTerminal();
-}
-
 window.onbeforeunload = () => {
     if (isDirty()) {
         return "You have unsaved changed, exit anyways?";
     }
 };
-
-fixViewportHeight();
-window.addEventListener("resize", fixViewportHeight);
 
 async function loadEditor() {
     let documentState = loadParameterizedContent();
@@ -428,7 +381,6 @@ async function loadEditor() {
     }
 
     updateUIConnected(true);
-    await changeMode(MODE_EDITOR);
 }
 
 var editor;
@@ -596,4 +548,160 @@ document.addEventListener('DOMContentLoaded', async (event) => {
     } else {
         await checkConnected();
     }
+});
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+const btnModeEditor = document.querySelector('.btn-mode-editor');
+const btnModeSerial = document.querySelector('.btn-mode-serial');
+
+const mainContent = document.getElementById('main-content');
+const editorPage = document.getElementById('editor-page');
+const serialPage = document.getElementById('serial-page');
+const pageSeparator = document.getElementById('page-separator');
+
+btnModeEditor.addEventListener('click', async function(e) {
+    if (btnModeEditor.classList.contains('active') && !btnModeSerial.classList.contains('active')) {
+        // this would cause both editor & serial pages to disappear
+        return;
+    }
+    btnModeEditor.classList.toggle('active');
+    editorPage.classList.toggle('active')
+    updatePageLayout(true, false);
+});
+
+btnModeSerial.addEventListener('click', async function(e) {
+    if (btnModeSerial.classList.contains('active') && !btnModeEditor.classList.contains('active')) {
+        // this would cause both editor & serial pages to disappear
+        return;
+    }
+    btnModeSerial.classList.toggle('active');
+    serialPage.classList.toggle('active')
+    updatePageLayout(false, true);
+});
+
+function updatePageLayout(editor=false, serial=false) {
+    if (editorPage.classList.contains('active') && serialPage.classList.contains('active')) {
+        pageSeparator.classList.add('active');
+    } else {
+        pageSeparator.classList.remove('active');
+        editorPage.style.width = null;
+        editorPage.style.flex = null;
+        serialPage.style.width = null;
+        serialPage.style.flex = null;
+        return;
+    }
+
+    if (mainContent.offsetWidth < 768) {
+        if (editor) {
+            btnModeSerial.classList.remove('active');
+            serialPage.classList.remove('active');
+        } else if (serial) {
+            btnModeEditor.classList.remove('active');
+            editorPage.classList.remove('active');
+        }
+        pageSeparator.classList.remove('active');
+    } else {
+        let w = mainContent.offsetWidth;
+        let s = pageSeparator.offsetWidth;
+        editorPage.style.width = ((w-s) / 2) + 'px';
+        editorPage.style.flex = '0 0 auto';
+        serialPage.style.width = ((w-s) / 2) + 'px';
+        serialPage.style.flex = '0 0 auto';
+    }
+
+    if (serial) {
+        refitTerminal();
+    }
+}
+
+function showEditor() {
+    btnModeEditor.classList.add('active');
+    editorPage.classList.add('active');
+    updatePageLayout(true, false);
+}
+
+function showSerial() {
+    btnModeSerial.classList.add('active');
+    serialPage.classList.add('active');
+    updatePageLayout(false, true);
+}
+
+function refitTerminal() {
+    // Re-fitting the terminal requires a full re-layout of the DOM which can be tricky to time right.
+    // see https://www.macarthur.me/posts/when-dom-updates-appear-to-be-asynchronous
+    window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+                if (fitter) {
+                    fitter.fit();
+                }
+            });
+        });
+    });
+}
+
+function fixViewportHeight() {
+    let vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+    refitTerminal();
+}
+fixViewportHeight();
+window.addEventListener("resize", fixViewportHeight);
+
+document.addEventListener('DOMContentLoaded', async (event) => {
+    function initResize(e) {
+        window.addEventListener('mousemove', Resize, false);
+        window.addEventListener('mouseup', stopResize, false);
+    }
+
+    function Resize(e) {
+        const w = mainContent.offsetWidth;
+        const s = pageSeparator.offsetWidth;
+        const r = e.clientX / w;
+        const hidingThreshold = 0.1;
+        const minimumThreshold = 0.2;
+        if (r < hidingThreshold) {
+            editorPage.classList.remove('active');
+            btnModeEditor.classList.remove('active');
+            updatePageLayout();
+            stopResize();
+            return;
+        } else if (r > 1-hidingThreshold) {
+            serialPage.classList.remove('active');
+            btnModeSerial.classList.remove('active');
+            updatePageLayout();
+            stopResize();
+            return;
+        } else if (r < minimumThreshold || r > 1-minimumThreshold) {
+            return;
+        }
+        editorPage.style.width = (e.clientX - s/2) + 'px';
+        serialPage.style.width = (w - e.clientX - s/2) + 'px';
+    }
+
+    function stopResize(e) {
+        window.removeEventListener('mousemove', Resize, false);
+        window.removeEventListener('mouseup', stopResize, false);
+    }
+
+    pageSeparator.addEventListener('mousedown', initResize, false);
 });

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,4 @@
+export default {
+    terminal: null,
+    fitter: null,
+}

--- a/js/workflows/workflow.js
+++ b/js/workflows/workflow.js
@@ -3,7 +3,7 @@ import {REPL} from 'circuitpython-repl-js';
 import {FileHelper} from '../common/file.js';
 import {UnsavedDialog} from '../common/dialogs.js';
 import {FileDialog, FILE_DIALOG_OPEN, FILE_DIALOG_SAVE} from '../common/file_dialog.js';
-import {MODE_SERIAL, CONNTYPE, CONNSTATE} from '../constants.js';
+import {CONNTYPE, CONNSTATE} from '../constants.js';
 
 /*
  * This class will encapsulate all of the common workflow-related functions
@@ -63,7 +63,7 @@ class Workflow {
             this.terminalTitle = params.terminalTitle;
         }
         this.currentFilename = params.currentFilename;
-        this._changeMode = params.changeModeFunc;
+        this._showSerial = params.showSerialFunc;
 
         this.repl.setTitle = this.setTerminalTitle.bind(this);
         this.repl.serialTransmit = this.serialTransmit.bind(this);
@@ -198,6 +198,8 @@ class Workflow {
             return false;
         }
 
+        await this._showSerial();
+
         if (path == "/code.py") {
             await this.repl.softRestart();
         } else {
@@ -205,7 +207,6 @@ class Workflow {
             path = path.replace(/\//g, ".");
             await (this.repl.runCode("import " + path));
         }
-        await this._changeMode(MODE_SERIAL);
     }
 
     async checkSaved() {

--- a/sass/base/_base.scss
+++ b/sass/base/_base.scss
@@ -16,12 +16,6 @@ body {
     margin: 0;
 }
 
-body {
-    @include viewport-height(0, min-height);
-    @include viewport-height(0);
-    position: relative;
-}
-
 a {
     text-decoration: none;
     color: inherit;
@@ -79,9 +73,7 @@ h5 {
     }
 }
 
-.purple-button.inverted,
-.mode-editor .btn-mode-serial,
-.mode-serial .btn-mode-editor {
+.purple-button.inverted {
     color: $purple;
     background-color: $gray;
 
@@ -93,13 +85,4 @@ h5 {
 .purple-button:disabled {
     background-color: #d8d8d8;
     color: #888;
-}
-
-fieldset {
-    border: 0;
-
-    legend {
-        font-size: 1.5em;
-        font-weight: 500;
-    }
 }

--- a/sass/base/_mixins.scss
+++ b/sass/base/_mixins.scss
@@ -34,23 +34,10 @@
     }
 }
 
-// Clearfix
 @mixin clearfix {
     &:after {
         content: "";
         display: table;
         clear: both;
-    }
-}
-
-@mixin viewport-height($offset, $property: height) {
-    @if $offset ==0 {
-        #{$property}: 100vh;
-        #{$property}: calc(var(--vh, 1vh) * 100);
-    }
-
-    @else {
-        #{$property}: calc(100vh - #{$offset});
-        #{$property}: calc(var(--vh, 1vh) * 100 - #{$offset});
     }
 }

--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -1,7 +1,7 @@
 @font-face {
     font-family: 'Proxima Nova';
     src: url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-light-webfont.woff2') format('woff2'),
-        url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-light-webfont.woff') format('woff');
+         url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-light-webfont.woff') format('woff');
     font-weight: 300;
     font-style: normal;
     letter-spacing: 0.3em;
@@ -10,7 +10,7 @@
 @font-face {
     font-family: 'Proxima Nova';
     src: url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-regular-webfont.woff2') format('woff2'),
-        url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-regular-webfont.woff') format('woff');
+         url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-regular-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }
@@ -18,7 +18,7 @@
 @font-face {
     font-family: 'Proxima Nova';
     src: url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-semibold-webfont.woff2') format('woff2'),
-        url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-semibold-webfont.woff') format('woff');
+         url('https://cdn-shop.adafruit.com/fonts/proximanova/proximanova-semibold-webfont.woff') format('woff');
     font-weight: 500;
     font-style: normal;
 }

--- a/sass/layout/_editor.scss
+++ b/sass/layout/_editor.scss
@@ -1,3 +1,9 @@
+.CodeMirror {
+    max-height: 1000px;
+    width: 100%;
+    height: 100%;
+}
+
 .cm-editor {
     color: #ddd;
     background-color: #333;

--- a/sass/layout/_header.scss
+++ b/sass/layout/_header.scss
@@ -5,13 +5,12 @@
 
     .wrapper {
         background-color: #333333;
-        height: 100px;
     }
 
     .content {
         display: grid;
-        padding-top: 20px;
-        padding-bottom: 20px;
+        padding-top: 10px;
+        padding-bottom: 10px;
     }
 
     a.active {
@@ -68,7 +67,7 @@
     width: 100%;
     display: flex;
     flex-direction: row;
-    align-items: flex-end;
+    align-items: center;
 }
 
 .site-banner {
@@ -80,11 +79,26 @@
     }
 }
 
+.site-logo {
+    display: flex;
+}
+
+.github-repo {
+    color: #fff;
+    font-size: 30px;
+    padding: 10px;
+    margin: 10px;
+    border-radius: 40px;
+
+    i {
+        vertical-align: middle;
+    }
+}
+
 .get-started {
     margin-left: auto;
     padding-bottom: 10px;
 
-    a,
     button {
         @include rounded-button;
         background-color: transparent;

--- a/sass/layout/_header.scss
+++ b/sass/layout/_header.scss
@@ -121,18 +121,6 @@
     text-overflow: ellipsis;
 }
 
-#footer-bar {
-    display: flex;
-
-    .spacer {
-        flex: auto;
-    }
-}
-
-#editor-bar, #serial-bar {
-    display: flex;
-}
-
 @media (max-width: $screen-xs-max) {
     #site-header {
         display: none !important;

--- a/sass/layout/_header_mobile.scss
+++ b/sass/layout/_header_mobile.scss
@@ -32,6 +32,8 @@
 }
 
 #mobile-editor-bar {
+    padding: 0 10px;
+
     #mobile-menu {
         float: left;
 
@@ -50,9 +52,8 @@
     #mobile-menu-contents {
         position: absolute;
         z-index: 2;
-        width: 100vh;
+        width: 100vw;
         left: 0;
-        top: 118px;
 
         &.hidden {
             display: none;

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -1,3 +1,107 @@
+.layout {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+
+    header {
+        // height: 5em;
+    }
+
+    #footer-bar {
+        // height: 5em;
+        padding: 0 10px;
+        display: flex;
+
+        .spacer {
+            flex: auto;
+        }
+    }
+}
+
+#page-separator {
+    display: none;
+    width: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    cursor: col-resize;
+    background-color: #9d9d9d;
+
+    &.active {
+        display: flex;
+        width: 8px;
+        flex: 0 0 8px;
+    }
+}
+
+#main-content {
+    flex: auto;
+    height: 100%;
+
+    display: flex;
+    flex-direction: row;
+
+    #editor-page, #serial-page {
+        flex: 1 1 100%;
+        display: none;
+        flex-direction: column;
+
+        &.active {
+            display: flex;
+        }
+    }
+
+    &.unsaved .file-path {
+        color: #f60;
+    }
+}
+
+#editor-bar, #serial-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 0 10px;
+    min-height: 60px
+}
+
+#editor-page {
+    #editor {
+        flex: 1 1 0%;
+        background: #333;
+    }
+}
+
+#serial-page {
+    #terminal {
+        flex: 1 1 0%;
+        background: #333;
+        position: relative;
+        width: 100%;
+        overflow: hidden;
+
+        .xterm .xterm-viewport {
+            background-color: transparent;
+            overflow-y: scroll;
+            cursor: default;
+            position: absolute;
+            inset: 0;
+            scrollbar-color: var(--highlight) var(--dark);
+            scrollbar-width: thin;
+            width: initial !important;
+
+            &::-webkit-scrollbar {
+                background-color: var(--dark);
+                width: 5px;
+            }
+
+            &::-webkit-scrollbar-thumb {
+                background: var(--highlight);
+            }
+        }
+    }
+}
+
+
 #ble-instructions,
 #web-instructions,
 #usb-instructions {
@@ -30,67 +134,25 @@
     }
 }
 
-#editor-bar,
-#serial-bar {
-    height: 59px;
-}
+.mode-button {
+    display: inline-block;
+    font-size: 1.1em;
+    width: auto;
+    padding: 0.5em 1em 0.5em 1em;
+    margin-right: 0.5em;
+    cursor: pointer;
+    white-space: nowrap;
+    border: none;
+    color: #fff;
+    background-color: $gray;
 
-#editor-page {
-    .editor-container {
-        background: #333;
-
-        .cm-editor {
-            @include viewport-height($terminal-height-offset-mobile);
-        }
-    }
-}
-
-#serial-page {
-    .terminal-container {
-        background: #333;
+    &:hover {
+        background-color: darken($gray, 15%);
     }
 
-    #terminal {
-        position: relative;
-        width: 100%;
-        @include viewport-height($terminal-height-offset-mobile);
-        overflow: hidden;
-
-        .xterm .xterm-viewport {
-            background-color: transparent;
-            overflow-y: scroll;
-            cursor: default;
-            position: absolute;
-            inset: 0;
-            scrollbar-color: var(--highlight) var(--dark);
-            scrollbar-width: thin;
-            width: initial !important;
-
-            &::-webkit-scrollbar {
-                background-color: var(--dark);
-                width: 5px;
-            }
-
-            &::-webkit-scrollbar-thumb {
-                background: var(--highlight);
-            }
-        }
-    }
-}
-
-@media (min-width: $screen-sm) {
-    #serial-page {
-        #terminal {
-            @include viewport-height($terminal-height-offset);
-        }
-    }
-
-    #editor-page {
-        .editor-container {
-            .cm-editor {
-                @include viewport-height($terminal-height-offset);
-            }
-        }
+    &.active {
+        color: #fff;
+        background-color: $purple;
     }
 }
 
@@ -117,30 +179,6 @@
     .popup-modal.connect-dialog {
         width: 768px;
     }
-}
-
-#main-content {
-    &.mode-editor {
-        #serial-page {
-            display: none;
-        }
-    }
-
-    &.mode-serial {
-        #editor-page {
-            display: none;
-        }
-    }
-
-    &.unsaved .file-path {
-        color: #f60;
-    }
-}
-
-.CodeMirror {
-    max-height: 1000px;
-    width: 100%;
-    height: 100%;
 }
 
 .loader {

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -10,9 +10,8 @@
 @import './base/mixins';
 @import './base/base';
 
+@import './layout/layout';
 @import './layout/grid';
+@import './layout/editor';
 @import './layout/header';
 @import './layout/header_mobile';
-
-@import './pages/code';
-@import './pages/editor';


### PR DESCRIPTION
_This PR is based on and includes #77. You can review the newer commits individually on this branch. Once #77 is merged, I'll rebase this PR here._

This PR adds a side-by-side layout to have the editor and serial next to each other ("split screen").

Each tab (or "page") can be toggled on and off using the buttons in the bottom left, which got re-styled to resemble the tab concept a bit more.

When both tabs are active, the vertical separator gap between them can be dragged around to resize the width of the split screen layout. A certain minimal width is maintained by simply stopping the resizing even if the mouse is moved further. Moving even beyond this minimal width will eventually collapse the split screen layout into a single tab layout.

This split screen mode is only available on wide enough screens, particularly the "mobile" layout and behaviour is unchanged.

Making use of the overhauled build system and folder structure in #77, this PR also separates the UI layout javascript code from the "business logic" javascript code in `script.js` and `layout.js`.

Minor other cosmetic changes are included as well, notably adding a GitHub icon + link to this repository in the header bar.

**Video demo:**

https://user-images.githubusercontent.com/114300/232224773-369abec8-de23-4580-a1c8-8c15a41c107f.mp4



