### PR TITLE
Add save button

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -30,6 +30,7 @@ const mainContent = document.getElementById('main-content');
 const btnConnect = document.querySelectorAll('.btn-connect');
 const btnNew = document.querySelectorAll('.btn-new');
 const btnOpen = document.querySelectorAll('.btn-open');
+const btnSave = document.querySelectorAll('.btn-save');
 const btnSaveAs = document.querySelectorAll('.btn-save-as');
 const btnSaveRun = document.querySelectorAll('.btn-save-run');
 const btnInfo = document.querySelector('.btn-info');
@@ -66,6 +67,16 @@ btnOpen.forEach((element) => {
         e.stopPropagation();
         await checkConnected();
         workflow.openFile();
+    });
+});
+
+// Save Link/Button (Mobile and Desktop Layout)
+btnSave.forEach((element) => {
+    element.addEventListener('click', async function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        await checkConnected();
+        await workflow.saveFile();
     });
 });
 
@@ -192,8 +203,11 @@ function setFilename(path) {
     let filename = path;
     if (path === null) {
         filename = "[New Document]";
+        btnSave.forEach((b) => b.style.display = 'none');
     } else if (!workflow) {
         throw Error("Unable to set path when no workflow is loaded");
+    } else {
+        btnSave.forEach((b) => b.style.display = null);
     }
     if (workflow) {
         workflow.currentFilename = path;

--- a/assets/js/workflows/workflow.js
+++ b/assets/js/workflows/workflow.js
@@ -184,22 +184,22 @@ class Workflow {
 
         if (!path) {
             console.log("File has not been saved");
-            return;
+            return false;
+        }
+
+        let extension = path.split('.').pop();
+        if (extension === null) {
+            console.log("Extension not found");
+            return false;
+        }
+        if (String(extension).toLowerCase() != "py") {
+            console.log("Extension not .py, it was ." + String(extension).toLowerCase());
+            return false;
         }
 
         if (path == "/code.py") {
             await this.repl.softRestart();
         } else {
-            let extension = path.split('.').pop();
-            if (extension === null) {
-                console.log("Extension not found");
-                return false;
-            }
-            if (String(extension).toLowerCase() != "py") {
-                console.log("Extension not py, it was " + String(extension).toLowerCase());
-                return false;
-            }
-
             path = path.slice(1, -3);
             path = path.replace(/\//g, ".");
             await (this.repl.runCode("import " + path));
@@ -239,15 +239,11 @@ class Workflow {
         let path = await this.saveFileDialog();
         if (path !== null) {
             // check if filename exists
-            if (path != this.currentFilename && await this.fileExists(path)) {
-                if (window.confirm("Overwrite existing file '" + path + "'?")) {
-                    await this.saveFile(path);
-                } else {
-                    return null;
-                }
-            } else {
-                await this.saveFile(path);
+            if (path != this.currentFilename && await this.fileExists(path) && !window.confirm("Overwrite existing file '" + path + "'?")) {
+                return null;
             }
+            this.currentFilename = path;
+            await this.saveFile(path);
         }
         return path;
     }

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
                         <ul>
                             <li><a class="btn-new">New<i class="fa-solid fa-plus"></i></a></li>
                             <li><a class="btn-open">Open<i class="fa-solid fa-folder-open"></i></a></li>
+                            <li><a class="btn-save">Save<i class="fa-solid fa-floppy-disk"></i></a></li>
                             <li><a class="btn-save-as">Save As<i class="fa-solid fa-download"></i></a></li>
                         </ul>
                     </nav>
@@ -76,6 +77,7 @@
                 <div id="editor-bar">
                     <button class="purple-button btn-new">New<i class="fa-solid fa-plus"></i></button>
                     <button class="purple-button btn-open">Open<i class="fa-solid fa-folder-open"></i></button>
+                    <button class="purple-button btn-save">Save<i class="fa-solid fa-floppy-disk"></i></button>
                     <button class="purple-button btn-save-as">Save As<i class="fa-solid fa-download"></i></button>
                     <div class="file-path"></div>
                     <button class="purple-button btn-save-run">Save + Run<i class="fa-solid fa-play"></i></button>


### PR DESCRIPTION
requires #87 to work properly. You can review only the most recent commit in this PR.

Editing config files or other non-code files was previously a challenge because the only options to save where "Save As" which required a few more (unnecessary) clicks to complete, or the "Save+Run" which obviously fails for non-code files.

This PR adds a simple "Save" button to the menu bar:


https://user-images.githubusercontent.com/114300/233834731-62f8b9d2-683f-4c2a-b577-6aadc709a2eb.mp4


The button is available in the mobile and the normal menu bar and only becomes visible once the editor has loaded a file.