### PR TITLE
fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ on:
 
 # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
The last merge to main failed to publish due to:
```
Push the commit or tag
  /usr/bin/git push origin gh-pages
  remote: Permission to circuitpython/web-editor.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/circuitpython/web-editor.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

The vite documentation seemingly contains incorrect permissions defaults:
https://vitejs.dev/guide/static-deploy.html

The used GitHub Action recommends additional write permissions for this workflow:
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token