### PR TITLE
Revert "Bump circuitpython-repl-js from 1.0.0 to 1.2.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@codemirror/lang-python": "^6.1.2",
         "@fortawesome/fontawesome-free": "^6.4.0",
         "ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.0.2",
-        "circuitpython-repl-js": "adafruit/circuitpython-repl-js#1.2.1",
+        "circuitpython-repl-js": "adafruit/circuitpython-repl-js#1.0.0",
         "codemirror": "^6.0.1",
         "file-saver": "^2.0.5",
         "idb-keyval": "^6.2.1",
@@ -244,8 +244,7 @@
     "node_modules/circuitpython-repl-js": {
       "name": "@adafruit/circuitpython-repl-js",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/adafruit/circuitpython-repl-js.git#ac42d9463e47bbd6d8011b803f309f37dd75d5ea",
-      "integrity": "sha512-I6igVFBgysij1l7qSuZ9kx6FLup69aZcIbArWfcssFMwTbSOcUJgyO8wvbsyGTee3UKqrPa8RRQ9lZUQIWLGGQ==",
+      "resolved": "git+ssh://git@github.com/adafruit/circuitpython-repl-js.git#3ae7ac1b1d8ed46a7d2dd34c0b8d0ec13f3e3700",
       "license": "MIT"
     },
     "node_modules/codemirror": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "xterm-addon-fit": "^0.7.0",
     "xterm-addon-web-links": "^0.8.0",
     "ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.0.2",
-    "circuitpython-repl-js": "adafruit/circuitpython-repl-js#1.2.1"
+    "circuitpython-repl-js": "adafruit/circuitpython-repl-js#1.0.0"
   }
 }


### PR DESCRIPTION
Reverts circuitpython/web-editor#92 due to issues when changing over.