### PR TITLE
Fix JSZip import, so files can download

### DIFF
--- a/js/common/file_dialog.js
+++ b/js/common/file_dialog.js
@@ -1,7 +1,7 @@
 import {GenericModal, ProgressDialog, ButtonValueDialog} from './dialogs.js';
 import {readUploadedFileAsArrayBuffer} from './utilities.js';
 import {saveAs} from 'file-saver';
-import {JSZip} from 'jszip';
+import JSZip from 'jszip';
 
 const FILE_DIALOG_OPEN = 1;
 const FILE_DIALOG_SAVE = 2;


### PR DESCRIPTION
This fixes the `Uncaught TypeError: JSZip is not a constructor` error that was happening when attempting to download a file. I'm not sure when this started happening, but changing the import fixed the issue.