### PR TITLE
Fix duplicate headings when fractional window sizes used

### DIFF
--- a/sass/layout/_header_mobile.scss
+++ b/sass/layout/_header_mobile.scss
@@ -1,4 +1,5 @@
 #mobile-header {
+    display: none;
     background-color: #333;
 
     .header-contents {
@@ -32,6 +33,7 @@
 }
 
 #mobile-editor-bar {
+    display: none;
     padding: 0 10px;
 
     #mobile-menu {
@@ -96,12 +98,12 @@
     }
 }
 
-@media (min-width: $screen-sm) {
+@media (max-width: $screen-xs-max) {
     #mobile-header {
-        display: none !important;
+        display: block !important;
     }
 
     #mobile-editor-bar {
-        display: none !important;
+        display: block !important;
     }
 }


### PR DESCRIPTION
Fixes #192. It was using a max and min value to determine when items were hidden only expecting integer values. Apparently chrome on windows allows float values for window sizes. So using both as max should solve the problem. Since I can't reproduce the issue on MacOS, I just tested locally that it still functions as expected.