### PR TITLE
save callback on this, and await folder functions

### DIFF
--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -21,6 +21,9 @@ class USBWorkflow extends Workflow {
         this._partialToken = null;
         this._uid = null;
         this._readLoopPromise = null;
+        this._btnSelectHostFolderCallback = null;
+        this._btnUseHostFolderCallback = null;
+
     }
 
     async init(params) {
@@ -163,18 +166,18 @@ class USBWorkflow extends Workflow {
         btnRequestSerialDevice.removeEventListener('click', serialConnect);
         btnRequestSerialDevice.addEventListener('click', serialConnect);
 
-        btnSelectHostFolder.removeEventListener('click', this.btnSelectHostFolderCallback)
-        this.btnSelectHostFolderCallback = async (event) => {
+        btnSelectHostFolder.removeEventListener('click', this._btnSelectHostFolderCallback)
+        this._btnSelectHostFolderCallback = async (event) => {
             await this._selectHostFolder();
         };
-        btnSelectHostFolder.addEventListener('click', this.btnSelectHostFolderCallback);
+        btnSelectHostFolder.addEventListener('click', this._btnSelectHostFolderCallback);
 
 
-        btnUseHostFolder.removeEventListener('click', this.btnUseHostFolderCallback);
-        this.btnUseHostFolderCallback = async (event) => {
+        btnUseHostFolder.removeEventListener('click', this._btnUseHostFolderCallback);
+        this._btnUseHostFolderCallback = async (event) => {
             await this._useHostFolder();
         }
-        btnUseHostFolder.addEventListener('click', this.btnUseHostFolderCallback);
+        btnUseHostFolder.addEventListener('click', this._btnUseHostFolderCallback);
 
         // Check if WebSerial is available
         if (!(await this.available() instanceof Error)) {

--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -163,11 +163,18 @@ class USBWorkflow extends Workflow {
         btnRequestSerialDevice.removeEventListener('click', serialConnect);
         btnRequestSerialDevice.addEventListener('click', serialConnect);
 
-        btnSelectHostFolder.removeEventListener('click', this._selectHostFolder);
-        btnSelectHostFolder.addEventListener('click', this._selectHostFolder);
+        btnSelectHostFolder.removeEventListener('click', this.btnSelectHostFolderCallback)
+        this.btnSelectHostFolderCallback = async (event) => {
+            await this._selectHostFolder();
+        };
+        btnSelectHostFolder.addEventListener('click', this.btnSelectHostFolderCallback);
 
-        btnUseHostFolder.removeEventListener('click', this._useHostFolder);
-        btnUseHostFolder.addEventListener('click', this._useHostFolder);
+
+        btnUseHostFolder.removeEventListener('click', this.btnUseHostFolderCallback);
+        this.btnUseHostFolderCallback = async (event) => {
+            await this._useHostFolder();
+        }
+        btnUseHostFolder.addEventListener('click', this.btnUseHostFolderCallback);
 
         // Check if WebSerial is available
         if (!(await this.available() instanceof Error)) {


### PR DESCRIPTION
This chang fixes an issue that is occurring for me in the beta version of the editor. Both the deployed beta page, and the beta branch when running locally behave the same for me and they're currently having this Javascript error when I click the 'Select Host Folder' or 'Use Host Folder' buttons 

```
index.js:94 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'getFileClient')
    at HTMLButtonElement._selectHostFolder (index.js:94:3384)
```
I added some additional console logging and found that `this.fileHelper` was indeed undefined when it tried to be accessed by this callback. 

I looked into the changes from main to beta and saw that these callbacks used to be wrapped in the anonymous async functions and awaited so I tried putting that back and it seems to resolve the issue. 

I also store the callback so that it can later be passed to `removeEventListener()` This is very similar to what ended up being a fix for the duplicated serial output, I'll submit a separate PR for that fix though as its unrelated to this JS error I believe.

I tested this version locally and found that with it I am now able to select the host folder successfully and carry on using the editor.