### PR TITLE
Fix duplicate serial console messages

### DIFF
--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -237,8 +237,8 @@ class USBWorkflow extends Workflow {
     async _switchToDevice(device) {
 
         device.removeEventListener("message", this.messageCallback);
-        this.messageCallback = this.onSerialReceive.bind(this);
-        device.addEventListener("message", this.messageCallback);
+        this._messageCallback = this.onSerialReceive.bind(this);
+        device.addEventListener("message", this._messageCallback);
 
         let onDisconnect = async (e) => {
             await this.onDisconnected(e, false);

--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -237,7 +237,7 @@ class USBWorkflow extends Workflow {
     // Workflow specific Functions
     async _switchToDevice(device) {
 
-        device.removeEventListener("message", this.messageCallback);
+        device.removeEventListener("message", this._messageCallback);
         this._messageCallback = this.onSerialReceive.bind(this);
         device.addEventListener("message", this._messageCallback);
 

--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -21,6 +21,7 @@ class USBWorkflow extends Workflow {
         this._partialToken = null;
         this._uid = null;
         this._readLoopPromise = null;
+        this._messageCallback = null;
     }
 
     async init(params) {

--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -235,8 +235,10 @@ class USBWorkflow extends Workflow {
 
     // Workflow specific Functions
     async _switchToDevice(device) {
-        device.removeEventListener("message", this.onSerialReceive.bind(this));
-        device.addEventListener("message", this.onSerialReceive.bind(this));
+
+        device.removeEventListener("message", this.messageCallback);
+        this.messageCallback = this.onSerialReceive.bind(this);
+        device.addEventListener("message", this.messageCallback);
 
         let onDisconnect = async (e) => {
             await this.onDisconnected(e, false);


### PR DESCRIPTION
Resolves #234 

I am not positive, but I think the existing `removeEventListener()` is not working because `this.onSerialReceive.bind(this)` is producing a new function each time it's called. So when it gets called for remove() technically it is a different instance of the function than the one that ends up being passed to `addEventListener()` and thus the one that will need to be passed next time to remove in order for it to get de-activated.

This resolves it by creating the callback once, storing it on `this` and then referencing it from there for both the add and remove listener calls.

I tested this locally and it does seem to resolve the duplicate serial issue, with it I can now disconnect / re-connect multiple times and still end up with just a single instance of the serial output.