### PR TITLE
Allow any address in .local for the web workflow

### DIFF
--- a/js/common/utilities.js
+++ b/js/common/utilities.js
@@ -41,10 +41,9 @@ function makeUrl(url, extraParams = {}) {
     return new URL(oldUrl) + buildHash(urlParams);
 }
 
-// Check if the current url is a valid CircuitPython Web Workflow local device name
+// Check for any local MDNS name, not limited to Circuitpython default names
 function isMdns() {
-    // Check for cpy-XXXXXX.local (and optionally cpy-XXXXXX-###.local for mDNS name resolution)
-    return location.hostname.search(/cpy-[0-9a-f]{6}(?:-[0-9]+)?.local/gi) == 0;
+    return location.hostname.endsWith(".local");
 }
 
 // Check if the current url is an IP address


### PR DESCRIPTION
The restriction on the hostname for web workflow is outdated but also incompatible with custom MDNS names.
So I believe it should just accept any `.local` name.

- since [circuitpython#9699](https://github.com/adafruit/circuitpython/pull/9699) the MDNS name no longer matches the filter used here.
  The format is now: cpy-*board_name*-*big_hex_number*.local
- when assigning a custom MDNS name to a board (with the `mdns` module) it's the url that is used by the web workflow, which redirects to it. Using a custom name is really useful to assign meaningful names to boards.

So for example with code like this, the web workflow doesn't work unless I use the IP instead of `circuitpython.local` (which is redirected to `bibliolights.local`).
```py
import mdns
import wifi
mdnserv = mdns.Server(wifi.radio)
mdnserv.hostname = "bibliolights"
```

Should fix #273 too.