### PR TITLE
remove \r from file contents when read via USB repl

### DIFF
--- a/js/common/repl-file-transfer.js
+++ b/js/common/repl-file-transfer.js
@@ -35,7 +35,7 @@ class FileTransferClient {
         if (contents === null) {
             return raw ? null : "";
         }
-        return contents;
+        return contents.replaceAll("\r\n", "\n");
     }
 
     async writeFile(path, offset, contents, modificationTime, raw = false) {


### PR DESCRIPTION
@ladyada 
Resolves: #285

When read via usb repl the file contains both `\r\n` and the code editor renders both as empty lines. This change strips the `\r` leaving only a `\n` to be rendered. 

Tested successfully on a locally running instance. 
![image](https://github.com/user-attachments/assets/363d64d3-3908-4807-b9cb-8f0df01d759a)
