### PR TITLE
Update to use Node 18 like on staging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
This is an update we already have on beta that works fine. Fixes an issue with updating to Vite 6.