### PR TITLE
Bump circuitpython-repl-js from 3.2.3 to 3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.0.2",
-        "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.2.2",
+        "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.2.4",
         "@codemirror/lang-python": "^6.1.6",
         "@fortawesome/fontawesome-free": "^6.6.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -30,6 +30,12 @@
         "@rollup/rollup-linux-x64-gnu": "^4.20.0"
       }
     },
+    "../../../circuitpython-repl-js/repl.js": {
+      "extraneous": true
+    },
+    "../../circuitpython-repl-js/repl.js": {
+      "extraneous": true
+    },
     "node_modules/@adafruit/ble-file-transfer-js": {
       "name": "@adafruit/ble-file-transfer",
       "version": "1.0.2",
@@ -37,8 +43,8 @@
       "license": "MIT"
     },
     "node_modules/@adafruit/circuitpython-repl-js": {
-      "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/adafruit/circuitpython-repl-js.git#2defa7c9489c2c84e471e861509027d5418b53ed",
+      "version": "3.2.4",
+      "resolved": "git+ssh://git@github.com/adafruit/circuitpython-repl-js.git#1bd2db05082d245afeb17bb1ffb2d66b7833f1ce",
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.0.2",
-    "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.2.3",
+    "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.2.4",
     "@codemirror/lang-python": "^6.1.6",
     "@fortawesome/fontawesome-free": "^6.6.0",
     "@xterm/addon-fit": "^0.10.0",


### PR DESCRIPTION
This is to address #249, but also fixes another bug I noticed where a newline was incorrectly being added when a file was opened.