### PR TITLE
Fix Serial Plotter

### DIFF
--- a/js/common/plotter.js
+++ b/js/common/plotter.js
@@ -45,6 +45,7 @@ export function plotValues(chartObj, serialMessage, bufferSize) {
         }
 
         let valuesToPlot;
+        let textValues;
 
         // handle possible tuple in textLine
         if (textLine.startsWith("(") && textLine.endsWith(")")) {


### PR DESCRIPTION
Declare `textValues` before setting a value to it.

Resolves: #382 