### PR TITLE
Return code output for Save+Run not with code.py

### DIFF
--- a/js/workflows/workflow.js
+++ b/js/workflows/workflow.js
@@ -214,7 +214,9 @@ class Workflow {
         } else {
             path = path.slice(1, -3);
             path = path.replace(/\//g, ".");
-            await (this.repl.runCode("import " + path));
+            this.repl.writeToTerminal("\r\nRunning 'import " + path + "'...\r\n");
+            this.repl.writeToTerminal(await (this.repl.runCode("import " + path)));
+            this.repl.writeToTerminal("\r\nCode done running.\r\n");
         }
     }
 


### PR DESCRIPTION
When doing testing on the USB workflow, I didn't see output from the code when using Save + Run button unless I was editing code.py (the code branches according to filename, restarting if code.py otherwise running in RAW mode).

This just outputs the fact import <file> is being called, and the result being printed, then the standard "Code done running." in case there is no output from the code.


It's also worth noting that there is a 15second timeout default when calling runCode, so that might want to be raised to infinity or something to allow code to continue to run. Issue there is we wouldn't see the output until it finishes (or at least that's my assumption)