### PR TITLE
fix(header): css for overflowing truncated title needs nowrap + title(tooltip) js sync

### DIFF
--- a/js/workflows/workflow.js
+++ b/js/workflows/workflow.js
@@ -183,6 +183,7 @@ class Workflow {
         }
 
         this.terminalTitle.textContent = title;
+        this.terminalTitle.title = title;
     }
 
     async showConnect(documentState) {

--- a/sass/layout/_header.scss
+++ b/sass/layout/_header.scss
@@ -138,6 +138,9 @@
     flex: auto;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+    flex-shrink: 1;
+    max-width: fit-content;
 }
 
 @media (max-width: $screen-xs-max) {

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -60,11 +60,14 @@
 
 #editor-bar, #serial-bar {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
     padding: 0 10px;
     min-height: 60px;
     height: 4em;
+}
+
+#editor-bar {
+    flex-wrap: wrap;
 }
 
 #editor-page {


### PR DESCRIPTION
Addresses the text overflowing part of https://github.com/circuitpython/web-editor/issues/409