### PR TITLE
wip(wifi workflow): DELETE method available doesn't represent writable on CPY 10.0.3 lilygot tdisplay S3, switch to fs json like circup

### DIFF
--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -7,7 +7,11 @@ class FileTransferClient {
 
     async readOnly() {
         await this._checkConnection();
-        return !this._allowedMethods.includes('DELETE');
+        console.log("Checking read only");
+        const response = await this._fetch("/fs/", {method: "GET", headers: {"Accept": "application/json"}})
+        const result = await response.json();
+        //TODO: Tyeth: cache this value until reconnection, as listdir / connect already fetch it
+        return result.writable === undefined || result.writable === false || !this._allowedMethods.includes("DELETE");
     }
 
     async _checkConnection() {
@@ -15,6 +19,7 @@ class FileTransferClient {
             throw new Error("Unable to perform file operation. Not Connected.");
         }
 
+        //TODO: Tyeth: reset this on reconnection
         if (this._allowedMethods === null) {
             const status = await this._fetch("/fs/", {method: "OPTIONS"});
             this._allowedMethods = status.headers.get("Access-Control-Allow-Methods").split(/,/).map(method => {return method.trim().toUpperCase();});

--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -53,16 +53,28 @@ class USBWorkflow extends Workflow {
 
     async onDisconnected(e, reconnect = true) {
         if (this.reader) {
-            await this.reader.cancel();
+            try {
+                await this.reader.cancel();
+            } catch (error) {
+                console.warn("Error calling reader.cancel:", error);
+            }
             this.reader = null;
         }
         if (this.writer) {
-            await this.writer.releaseLock();
+            try {
+                await this.writer.releaseLock();
+            } catch (error) {
+                console.warn("Error calling writer.releaseLock:", error);
+            }
             this.writer = null;
         }
 
         if (this._serialDevice) {
-            await this._serialDevice.close();
+            try {
+                await this._serialDevice.close();
+            } catch (error) {
+                console.warn("Error calling _serialDevice.close:", error);
+            }
             this._serialDevice = null;
         }
 
@@ -273,7 +285,11 @@ class USBWorkflow extends Workflow {
         device.addEventListener("message", this._messageCallback);
 
         let onDisconnect = async (e) => {
-            await this.onDisconnected(e, false);
+            try {
+                await this.onDisconnected(e, false);
+            } catch (error) {
+                console.warn("Error calling onDisconnected (maybe already disconnected):", error);
+            }
         };
         device.removeEventListener("disconnect", onDisconnect);
         device.addEventListener("disconnect", onDisconnect);


### PR DESCRIPTION
This switches to using the file web api response to get the writable state, which is returned whenever the listDir api is used.

On the lilygo T-Display S3 the HTTP PUT failed due to not being writable, and the http response was something like "USB ACTIVE, try reseting board" or something like that, but the response text is not displayed in console nor to user.

Looking deeper, the PUT request should have been skipped, due to writable: false being part of the listDir response for "/".
Checking the current readOnly code, it checks for an HTTP OPTIONS query and inspects the returned methods for DELETE, which **was present** when my device was **not writable**. The JSON property was correctly returned.

This switches to using the /fs/ API check instead of relying on HTTP DELETE method being supported.

It's probably worth refactoring this into a class level flag thats updated with each listDir and then cached, until a disconnect event or failed write call at which point it's forcefully refreshed.

Calling like it currently does at each call of readOnly is actually fine (at least on a responsive wifi network).