### PR TITLE
Fix infinite save retry loop and method check bugs

### DIFF
--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -89,7 +89,7 @@ class FileTransferClient {
         };
 
         if (fetchOptions.method && fetchOptions.method.toUpperCase() != 'OPTIONS') {
-            if (!this._isMethodAllowed(fetchOptions.method)) {
+            if (!await this._isMethodAllowed(fetchOptions.method)) {
                 if (fetchOptions.method.toUpperCase() == "MOVE") {
                     // This should only happen if rename is used and the user doesn't have latest version
                     console.warn("Please upgrade to the latest version of CircuitPython. Allowing MOVE for now.");
@@ -114,7 +114,7 @@ class FileTransferClient {
 
     async _isMethodAllowed(method) {
         if (this._allowedMethods) {
-            return this._allowedMethods.includes(method.toUpperCase);
+            return this._allowedMethods.includes(method.toUpperCase());
         }
 
         return false;

--- a/js/script.js
+++ b/js/script.js
@@ -462,6 +462,8 @@ async function loadEditor() {
 
 var editor;
 var currentTimeout = null;
+var saveRetryCount = 0;
+const MAX_SAVE_RETRIES = 3;
 
 // Save the File Contents and update the UI
 async function saveFileContents(path) {
@@ -482,8 +484,9 @@ async function saveFileContents(path) {
         if (await workflow.writeFile(path, contents, offset)) {
             setFilename(workflow.currentFilename);
             setSaved(true);
+            saveRetryCount = 0;
         } else {
-            await showMessage(`Saving file '${workflow.currentFilename} failed.`);
+            await showMessage(`Saving file '${workflow.currentFilename}' failed.`);
         }
     } catch (e) {
         console.error("write failed", e, e.stack);
@@ -491,7 +494,14 @@ async function saveFileContents(path) {
         if (currentTimeout != null) {
             clearTimeout(currentTimeout);
         }
-        currentTimeout = setTimeout(saveFileContents, 2000);
+        saveRetryCount++;
+        if (saveRetryCount < MAX_SAVE_RETRIES) {
+            console.log(`Save retry ${saveRetryCount} of ${MAX_SAVE_RETRIES}...`);
+            currentTimeout = setTimeout(saveFileContents, 2000);
+        } else {
+            saveRetryCount = 0;
+            await showMessage(`Saving file '${workflow.currentFilename}' failed after multiple attempts. Check your connection and try again.`);
+        }
     }
 }
 
@@ -535,6 +545,11 @@ async function onTextChange(update) {
 }
 
 function disconnectCallback() {
+    if (currentTimeout != null) {
+        clearTimeout(currentTimeout);
+        currentTimeout = null;
+    }
+    saveRetryCount = 0;
     updateUIConnected(false);
 }
 


### PR DESCRIPTION
## Summary

Fixes #460 — Cannot Save code.py Edits on Adafruit Qualia ESP32-S3

### The Problem

When saving a file fails (e.g., due to a connection issue or board being busy), `saveFileContents()` catches the error and retries via `setTimeout(saveFileContents, 2000)` with **no retry limit**. This creates an infinite loop that:

- Retries the save every 2 seconds forever
- Causes the editor to appear to "reload" continuously (as reported in #460)
- Never shows the user an error message
- Continues even after disconnecting or switching to a different board

### Changes

**js/script.js:**
- Add a retry counter with a max of 3 attempts for `saveFileContents()`
- Show a clear error message to the user when retries are exhausted
- Reset retry counter on successful save
- Clear the retry timeout and reset counter on disconnect (prevents phantom retries after switching boards)
- Fix missing closing quote in save failure message template literal

**js/common/web-file-transfer.js:**
- Fix `_isMethodAllowed()`: `method.toUpperCase` was missing `()`, passing the function reference instead of calling it — so the method check always returned `false`
- Add missing `await` on `_isMethodAllowed()` call in `_fetch()` so the permission check result is actually evaluated (previously the unawaited Promise was always truthy, making the check dead code)

### Testing

- Build passes with `vite build`
- The Qualia-specific save failure likely has a firmware component too (display DMA contention during web server PUT), but this fix prevents the editor from looping forever regardless of the cause