### PR TITLE
Fix BLE disconnect crash and event listener leaks

### DIFF
--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -34,6 +34,10 @@ class BLEWorkflow extends Workflow {
             {reconnect: false, request: true},
             {reconnect: true, request: true},
         ];
+
+        // Store bound event handlers so they can be properly removed
+        this._boundOnDisconnected = this.onDisconnected.bind(this);
+        this._boundOnSerialReceive = this.onSerialReceive.bind(this);
     }
 
     // This is called when a user clicks the main disconnect button
@@ -102,8 +106,8 @@ class BLEWorkflow extends Workflow {
             this.rxCharacteristic = await this.serialService.getCharacteristic(bleNusCharRXUUID);
 
             // Remove any existing event listeners to prevent multiple reads
-            this.txCharacteristic.removeEventListener('characteristicvaluechanged', this.onSerialReceive.bind(this));
-            this.txCharacteristic.addEventListener('characteristicvaluechanged', this.onSerialReceive.bind(this));
+            this.txCharacteristic.removeEventListener('characteristicvaluechanged', this._boundOnSerialReceive);
+            this.txCharacteristic.addEventListener('characteristicvaluechanged', this._boundOnSerialReceive);
             await this.txCharacteristic.startNotifications();
             return true;
         } catch (e) {
@@ -144,7 +148,12 @@ class BLEWorkflow extends Workflow {
     async connectToBluetoothDevice(device) {
         const abortController = new AbortController();
 
-        async function onAdvertisementReceived(event) {
+        // Remove previous advertisement listener if one was stored
+        if (this._boundOnAdvertisementReceived) {
+            device.removeEventListener('advertisementreceived', this._boundOnAdvertisementReceived);
+        }
+
+        this._boundOnAdvertisementReceived = (async function onAdvertisementReceived(event) {
             console.log('> Received advertisement from "' + device.name + '"...');
             // Stop watching advertisements to conserve battery life.
             abortController.abort();
@@ -164,10 +173,9 @@ class BLEWorkflow extends Workflow {
             } else {
                 console.log('Unable to connect to bluetooth device "' +  device.name + '.');
             }
-        }
+        }).bind(this);
 
-        device.removeEventListener('advertisementreceived', onAdvertisementReceived.bind(this));
-        device.addEventListener('advertisementreceived', onAdvertisementReceived.bind(this));
+        device.addEventListener('advertisementreceived', this._boundOnAdvertisementReceived);
 
         this.debugLog("Attempting to connect to " + device.name + "...");
         try {
@@ -199,8 +207,8 @@ class BLEWorkflow extends Workflow {
 
     async switchToDevice(device) {
         this.bleDevice = device;
-        this.bleDevice.removeEventListener("gattserverdisconnected", this.onDisconnected.bind(this));
-        this.bleDevice.addEventListener("gattserverdisconnected", this.onDisconnected.bind(this));
+        this.bleDevice.removeEventListener("gattserverdisconnected", this._boundOnDisconnected);
+        this.bleDevice.addEventListener("gattserverdisconnected", this._boundOnDisconnected);
         console.log("connected", this.bleServer);
 
         try {
@@ -267,7 +275,9 @@ class BLEWorkflow extends Workflow {
 
     updateConnected(connectionState) {
         super.updateConnected(connectionState);
-        this.connectionStep(2);
+        if (this.connectDialog && this.connectDialog.isOpen()) {
+            this.connectionStep(2);
+        }
     }
 
     async available() {


### PR DESCRIPTION
## Summary

Fixes #377 — BLE disconnect during file write operations throws `Modal has not been opened yet. No instance available` and, in most cases, prevents the UI from being used again without a page refresh.

## Root cause

Two separate bugs in `js/workflows/ble.js` compound into the reported crash:

### Bug 1 — `connectionStep()` called when no dialog is open

When BLE disconnects **mid-file-write** (not during the connect flow), the chain is:

```
gattserverdisconnected event
  → onDisconnected()          (workflow.js)
    → updateConnected(false)   (workflow.js)
      → connectionStep(2)      (ble.js override)
        → _markStepCompleted(2)
          → this.connectDialog.getModal()  ❌ throws
```

`getModal()` throws because `connectDialog` was never opened in this lifecycle — the user was editing a file, not walking the connect wizard. This matches the stack trace in the issue exactly.

### Bug 2 — Event listener removal no-ops

`switchToDevice()` and `connectToSerial()` attempt to clean up listeners with:

```js
device.removeEventListener('gattserverdisconnected', this.onDisconnected.bind(this));
```

Every `.bind(this)` call returns a **new function reference**, so `removeEventListener` never matches the previously-added listener. Each reconnect leaks another handler, causing duplicate disconnect callbacks (which makes Bug 1 fire multiple times on a single disconnect).

The same pattern exists for `onSerialReceive` and the advertisement listener in `connectToBluetoothDevice()`.

## Fix

1. **Guard `connectionStep()` in `updateConnected()`** behind `connectDialog.isOpen()` so step-marking only runs when the dialog actually exists.
2. **Store bound handlers in the constructor** (`_boundOnDisconnected`, `_boundOnSerialReceive`) and reuse the same reference for both `addEventListener` and `removeEventListener`.
3. **Fix advertisement listener cleanup** in `connectToBluetoothDevice()` the same way (`_boundOnAdvertisementReceived`), and remove any previous listener before attaching a new one.

## Testing

- `npx vite build` passes cleanly.
- Reproduced the crash signature against the unpatched `getModal()` path and verified the guard short-circuits it while preserving normal behavior when the dialog is open:

  | Scenario | Unpatched | Patched |
  |---|---|---|
  | Disconnect while connect dialog **closed** (the bug) | ❌ `Modal has not been opened yet` | ✅ Skipped safely |
  | Normal connect with dialog **open** | ✅ Works | ✅ Works |

- Hardware end-to-end (file write → disconnect) testing was limited by Linux Chromium `watchAdvertisements` flakiness; local-only bench review confirms the listener-identity fix, and reviewers on macOS/Windows Chrome can exercise the full flow.

## Notes

Only `js/workflows/ble.js` is modified. No behavior change for connected users or normal flows — only the error path is fixed.