### PR TITLE
Detect read-only BLE filesystem via write probe (workaround for #376)

### DIFF
--- a/js/common/ble-file-transfer.js
+++ b/js/common/ble-file-transfer.js
@@ -8,17 +8,30 @@ class FileTransferClient extends BLEFileTransferClient {
     }
 
     async readOnly() {
-        let readonly = false;
-        return false;
-        // Check if the device is read only
-        console.log("Checking if device is read only");
-        // Attempt to write a 0-byte temp file and remove it
+        // Probe whether the BLE filesystem accepts writes.
+        //
+        // We can't rely on a specific firmware status code: older CircuitPython
+        // returned STATUS_ERROR_READONLY (0x05), but recent versions collapse that
+        // into STATUS_ERROR (0x02) on some code paths (see issue #376 and
+        // adafruit/circuitpython#10972). Instead, attempt to create and delete a
+        // hidden zero-byte file at the root and treat any failure as read-only.
         const testPath = '/._ble_readonly_check';
+        let readonly = false;
+        let wrote = false;
         try {
             await this.writeFile(testPath, 0, new Uint8Array(0));
-            await this.deleteFile(testPath);
+            wrote = true;
         } catch (e) {
             readonly = true;
+        }
+        if (wrote) {
+            // Best-effort cleanup; if the delete fails we still consider the FS
+            // writable since the write succeeded.
+            try {
+                await this.deleteFile(testPath);
+            } catch (e) {
+                console.warn("Failed to clean up read-only probe file:", e);
+            }
         }
         return readonly;
     }


### PR DESCRIPTION
Fixes #376 (workaround).

## Problem

When CIRCUITPY is mounted read-only (USB MSC owns the filesystem), BLE file operations from the web editor fail silently — no error dialog, just unhelpful console errors and broken Save As / Upload / Rename / Move flows.

The web editor already has the plumbing for this case: `fileHelper.readOnly()`, the `_readOnlyMode` flag in the file dialog, and disabled Save As / Save+Run buttons in `script.js`. The probe is just short-circuited with an early `return false`, which is why it never fires.

The original detection relied on the firmware returning `STATUS_ERROR_READONLY` (0x05). Recent CircuitPython collapses that into the generic `STATUS_ERROR` (0x02) on some code paths (see [adafruit/circuitpython#10972](https://github.com/adafruit/circuitpython/issues/10972)), so even bringing the old probe back wouldn't be enough to distinguish read-only from other errors purely by status code.

## Fix

Drop the early `return false` and use a status-code-agnostic probe: attempt to write a hidden zero-byte file (`/._ble_readonly_check`) at the root and treat **any** failure as read-only. Cleanup of the probe file is best-effort and only attempted when the write succeeded.

This works on both old (0x05) and new (0x02) firmware, since it doesn't care which error code we got — only whether the write completed.

## Effect

Once the probe correctly returns `true`:
- `script.js: checkReadOnly()` shows the existing warning: *"Warning: File System is in read only mode. Disable the USB drive to allow write access."*
- Save As and Save+Run buttons get disabled
- In the file dialog, Upload / New Folder / Rename / Move / Delete are all disabled by the existing `_readOnlyMode` guards

## Verification

- `npm run build` clean (vite v8.0.10, 52 modules, ~2.7s)
- Probe is hidden filename (`._` prefix), zero bytes, deleted immediately on success
- Probe path is the root `/`, which is always valid on CircuitPython, so no false positives from "Invalid Path"

## Notes

- This is a **client-side workaround**. The real firmware fix (restore `STATUS_ERROR_READONLY` on read-only operations) is tracked in [adafruit/circuitpython#10972](https://github.com/adafruit/circuitpython/issues/10972). Even after that lands, this probe is still useful — it doesn't depend on a specific firmware version.
- Single file changed: `js/common/ble-file-transfer.js` (+19 / -6).