### PR TITLE
Add CircuitPython module highlighting overlay

### DIFF
--- a/js/common/circuitpython_highlight.js
+++ b/js/common/circuitpython_highlight.js
@@ -1,0 +1,200 @@
+// CircuitPython syntax highlighting overlay for CodeMirror 6.
+//
+// CodeMirror 6 dropped the simple `extra_keywords` mechanism that CM5 had,
+// so instead of forking @codemirror/lang-python we layer extra decorations
+// on top of the existing Python syntax tree. We walk the tree inside the
+// viewport, find identifier nodes whose text matches a CircuitPython name,
+// and tag them with a CSS class that the theme can style.
+
+import { ViewPlugin, Decoration } from "@codemirror/view";
+import { syntaxTree } from "@codemirror/language";
+
+// CircuitPython core/built-in modules. These are the names that appear in
+// `import foo` / `from foo import ...` inside CircuitPython code and are
+// the most consistent thing we can match without parsing semantics.
+//
+// Keep this list focused on modules that ship with CircuitPython (or are
+// extremely common Adafruit libraries). Anything we add here will be
+// highlighted whenever the identifier appears, so we want low false-positive
+// risk against regular Python code.
+const CIRCUITPYTHON_MODULES = new Set([
+    // Core built-in CircuitPython modules
+    "adafruit_bus_device",
+    "aesio",
+    "alarm",
+    "analogbufio",
+    "analogio",
+    "atexit",
+    "audiobusio",
+    "audiocore",
+    "audioio",
+    "audiomixer",
+    "audiomp3",
+    "audiopwmio",
+    "bitbangio",
+    "bitmapfilter",
+    "bitmaptools",
+    "bitops",
+    "board",
+    "busdisplay",
+    "busio",
+    "canio",
+    "codeop",
+    "countio",
+    "digitalio",
+    "displayio",
+    "dotclockframebuffer",
+    "dualbank",
+    "epaperdisplay",
+    "espidf",
+    "espnow",
+    "espulp",
+    "floppyio",
+    "fontio",
+    "framebufferio",
+    "frequencyio",
+    "getpass",
+    "gifio",
+    "i2cdisplaybus",
+    "i2cperipheral",
+    "i2ctarget",
+    "imagecapture",
+    "is31fl3741",
+    "jpegio",
+    "keypad",
+    "keypad_demux",
+    "lsm6ds",
+    "max3421e",
+    "mdns",
+    "memorymap",
+    "memorymonitor",
+    "microcontroller",
+    "msgpack",
+    "neopixel_write",
+    "nvm",
+    "onewireio",
+    "paralleldisplay",
+    "paralleldisplaybus",
+    "picodvi",
+    "pulseio",
+    "pwmio",
+    "qrio",
+    "rainbowio",
+    "rgbmatrix",
+    "rotaryio",
+    "rp2pio",
+    "rtc",
+    "sdcardio",
+    "sdioio",
+    "sharpdisplay",
+    "socketpool",
+    "spitarget",
+    "ssl",
+    "storage",
+    "supervisor",
+    "synthio",
+    "terminalio",
+    "tilepalettemapper",
+    "touchio",
+    "traceback",
+    "uheap",
+    "ulab",
+    "usb",
+    "usb_cdc",
+    "usb_hid",
+    "usb_host",
+    "usb_midi",
+    "usb_video",
+    "ustack",
+    "vectorio",
+    "warnings",
+    "watchdog",
+    "wifi",
+    "zlib",
+
+    // Very common Adafruit/CircuitPython community libraries that users see
+    // imported all the time. Underscore-prefixed Adafruit names are already
+    // distinctive enough that false positives are essentially nil.
+    "adafruit_ble",
+    "adafruit_connection_manager",
+    "adafruit_datetime",
+    "adafruit_display_shapes",
+    "adafruit_display_text",
+    "adafruit_displayio_layout",
+    "adafruit_displayio_sh1106",
+    "adafruit_displayio_ssd1306",
+    "adafruit_dotstar",
+    "adafruit_fakerequests",
+    "adafruit_framebuf",
+    "adafruit_hid",
+    "adafruit_httpserver",
+    "adafruit_imageload",
+    "adafruit_io",
+    "adafruit_logging",
+    "adafruit_matrixportal",
+    "adafruit_minimqtt",
+    "adafruit_motor",
+    "adafruit_ntp",
+    "adafruit_pixelbuf",
+    "adafruit_pixelmap",
+    "adafruit_portalbase",
+    "adafruit_register",
+    "adafruit_requests",
+    "adafruit_sdcard",
+    "adafruit_seesaw",
+    "adafruit_simplemath",
+    "adafruit_ticks",
+    "neopixel",
+    "simpleio",
+]);
+
+const moduleMark = Decoration.mark({ class: "tok-cp-module" });
+
+// Build the decoration set for the part of the document currently visible.
+// Walking only visible ranges keeps this cheap on big files.
+function buildDecorations(view) {
+    const builder = [];
+    for (const { from, to } of view.visibleRanges) {
+        syntaxTree(view.state).iterate({
+            from,
+            to,
+            enter(node) {
+                // We care about identifier-like leaves only. Lezer Python emits
+                // `VariableName` for bare identifiers (including module names
+                // in `import foo` and `from foo import ...`). Module names
+                // accessed as attributes (e.g. `adafruit_io.MQTT`) come in as
+                // `VariableName` for the leftmost part, then `PropertyName`
+                // children — we only mark the root reference.
+                if (node.name !== "VariableName") return;
+                const text = view.state.doc.sliceString(node.from, node.to);
+                if (CIRCUITPYTHON_MODULES.has(text)) {
+                    builder.push(moduleMark.range(node.from, node.to));
+                }
+            },
+        });
+    }
+    // Decoration ranges must be sorted by `from`, which they already are
+    // because we iterate the tree in document order.
+    return Decoration.set(builder);
+}
+
+// ViewPlugin keeps decorations in sync with viewport / document changes.
+export const circuitpythonHighlight = ViewPlugin.fromClass(
+    class {
+        constructor(view) {
+            this.decorations = buildDecorations(view);
+        }
+        update(update) {
+            if (
+                update.docChanged ||
+                update.viewportChanged ||
+                syntaxTree(update.startState) !== syntaxTree(update.state)
+            ) {
+                this.decorations = buildDecorations(update.view);
+            }
+        }
+    },
+    {
+        decorations: (v) => v.decorations,
+    },
+);

--- a/js/common/circuitpython_highlight.js
+++ b/js/common/circuitpython_highlight.js
@@ -9,17 +9,15 @@
 import { ViewPlugin, Decoration } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
 
-// CircuitPython core/built-in modules. These are the names that appear in
-// `import foo` / `from foo import ...` inside CircuitPython code and are
-// the most consistent thing we can match without parsing semantics.
+// Core/built-in CircuitPython modules. These are the identifiers that show
+// up in `import foo` / `from foo import ...` inside CircuitPython code.
 //
-// Keep this list focused on modules that ship with CircuitPython (or are
-// extremely common Adafruit libraries). Anything we add here will be
-// highlighted whenever the identifier appears, so we want low false-positive
-// risk against regular Python code.
-const CIRCUITPYTHON_MODULES = new Set([
-    // Core built-in CircuitPython modules
-    "adafruit_bus_device",
+// Anything in this set is highlighted whenever it appears as a bare
+// identifier, so it should stay focused on names that ship with
+// CircuitPython itself. Third-party Adafruit libraries are matched by
+// the `adafruit_` prefix below instead of being listed individually,
+// which avoids list maintenance every time a new library lands on PyPI.
+const CIRCUITPYTHON_CORE_MODULES = new Set([
     "aesio",
     "alarm",
     "analogbufio",
@@ -112,41 +110,23 @@ const CIRCUITPYTHON_MODULES = new Set([
     "wifi",
     "zlib",
 
-    // Very common Adafruit/CircuitPython community libraries that users see
-    // imported all the time. Underscore-prefixed Adafruit names are already
-    // distinctive enough that false positives are essentially nil.
-    "adafruit_ble",
-    "adafruit_connection_manager",
-    "adafruit_datetime",
-    "adafruit_display_shapes",
-    "adafruit_display_text",
-    "adafruit_displayio_layout",
-    "adafruit_displayio_sh1106",
-    "adafruit_displayio_ssd1306",
-    "adafruit_dotstar",
-    "adafruit_fakerequests",
-    "adafruit_framebuf",
-    "adafruit_hid",
-    "adafruit_httpserver",
-    "adafruit_imageload",
-    "adafruit_io",
-    "adafruit_logging",
-    "adafruit_matrixportal",
-    "adafruit_minimqtt",
-    "adafruit_motor",
-    "adafruit_ntp",
-    "adafruit_pixelbuf",
-    "adafruit_pixelmap",
-    "adafruit_portalbase",
-    "adafruit_register",
-    "adafruit_requests",
-    "adafruit_sdcard",
-    "adafruit_seesaw",
-    "adafruit_simplemath",
-    "adafruit_ticks",
+    // Bare-named community modules without the `adafruit_` prefix that are
+    // common enough to be worth recognising explicitly.
     "neopixel",
     "simpleio",
 ]);
+
+// Returns true when `name` is a CircuitPython module worth highlighting.
+// Wildcard-matches anything starting with `adafruit_` so new libraries
+// (e.g. `adafruit_foo_bar` shipped next month) light up automatically
+// without touching this file.
+function isCircuitPythonModule(name) {
+    if (CIRCUITPYTHON_CORE_MODULES.has(name)) return true;
+    if (name.startsWith("adafruit_") && name.length > "adafruit_".length) {
+        return true;
+    }
+    return false;
+}
 
 const moduleMark = Decoration.mark({ class: "tok-cp-module" });
 
@@ -167,7 +147,7 @@ function buildDecorations(view) {
                 // children — we only mark the root reference.
                 if (node.name !== "VariableName") return;
                 const text = view.state.doc.sliceString(node.from, node.to);
-                if (CIRCUITPYTHON_MODULES.has(text)) {
+                if (isCircuitPythonModule(text)) {
                     builder.push(moduleMark.range(node.from, node.to));
                 }
             },

--- a/js/common/circuitpython_highlight.js
+++ b/js/common/circuitpython_highlight.js
@@ -8,6 +8,7 @@
 
 import { ViewPlugin, Decoration } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
+import { Prec } from "@codemirror/state";
 
 // Core/built-in CircuitPython modules. These are the identifiers that show
 // up in `import foo` / `from foo import ...` inside CircuitPython code.
@@ -191,7 +192,7 @@ function buildDecorations(view) {
 }
 
 // ViewPlugin keeps decorations in sync with viewport / document changes.
-export const circuitpythonHighlight = ViewPlugin.fromClass(
+const circuitpythonHighlightPlugin = ViewPlugin.fromClass(
     class {
         constructor(view) {
             this.decorations = buildDecorations(view);
@@ -210,3 +211,11 @@ export const circuitpythonHighlight = ViewPlugin.fromClass(
         decorations: (v) => v.decorations,
     },
 );
+
+// Wrap the plugin with Prec.highest so its decoration nests inside the
+// classHighlighter span. CodeMirror renders overlapping mark decorations
+// as nested spans where higher-precedence decorations end up closer to
+// the text. The inner span’s `color` is what the user sees, so making
+// `tok-cp-module` the inner class is what lets our pink override the
+// underlying `tok-variableName` blue without resorting to !important.
+export const circuitpythonHighlight = Prec.highest(circuitpythonHighlightPlugin);

--- a/js/common/circuitpython_highlight.js
+++ b/js/common/circuitpython_highlight.js
@@ -12,11 +12,22 @@ import { syntaxTree } from "@codemirror/language";
 // Core/built-in CircuitPython modules. These are the identifiers that show
 // up in `import foo` / `from foo import ...` inside CircuitPython code.
 //
-// Anything in this set is highlighted whenever it appears as a bare
-// identifier, so it should stay focused on names that ship with
-// CircuitPython itself. Third-party Adafruit libraries are matched by
-// the `adafruit_` prefix below instead of being listed individually,
-// which avoids list maintenance every time a new library lands on PyPI.
+// Sourced from the upstream `shared-bindings/` directory in
+// adafruit/circuitpython, plus port-specific bindings that are widely used
+// (espidf/espnow/espulp on ESP, picodvi/rp2pio on RP2). Standard-Python
+// modules that CircuitPython also exposes (math, os, time, random, struct,
+// hashlib, ipaddress, locale, __future__) are intentionally omitted — they
+// aren't CircuitPython-specific and highlighting them as such would be
+// noisy in regular Python code shown in the editor.
+//
+// Underscore-prefixed internal bindings (_bleio, _eve, _pew, _pixelmap,
+// _stage) are also omitted; users access those via the corresponding
+// `adafruit_*` libraries which are matched by the prefix wildcard below.
+//
+// Third-party Adafruit libraries are matched by the `adafruit_` prefix
+// instead of being listed individually, and community-bundle libraries by
+// the `circuitpython_` prefix, so this set only needs updating when a new
+// shared binding lands upstream.
 const CIRCUITPYTHON_CORE_MODULES = new Set([
     "aesio",
     "alarm",
@@ -25,10 +36,15 @@ const CIRCUITPYTHON_CORE_MODULES = new Set([
     "atexit",
     "audiobusio",
     "audiocore",
+    "audiodelays",
+    "audiofilters",
+    "audiofreeverb",
     "audioio",
     "audiomixer",
     "audiomp3",
     "audiopwmio",
+    "audiospeed",
+    "aurora_epaper",
     "bitbangio",
     "bitmapfilter",
     "bitmaptools",
@@ -36,6 +52,7 @@ const CIRCUITPYTHON_CORE_MODULES = new Set([
     "board",
     "busdisplay",
     "busio",
+    "camera",
     "canio",
     "codeop",
     "countio",
@@ -49,35 +66,41 @@ const CIRCUITPYTHON_CORE_MODULES = new Set([
     "espulp",
     "floppyio",
     "fontio",
+    "fourwire",
     "framebufferio",
     "frequencyio",
     "getpass",
     "gifio",
+    "gnss",
     "i2cdisplaybus",
-    "i2cperipheral",
+    "i2cioexpander",
     "i2ctarget",
     "imagecapture",
     "is31fl3741",
     "jpegio",
     "keypad",
     "keypad_demux",
-    "lsm6ds",
+    "lvfontio",
     "max3421e",
+    "mcp4822",
     "mdns",
     "memorymap",
     "memorymonitor",
     "microcontroller",
+    "mipidsi",
     "msgpack",
     "neopixel_write",
     "nvm",
     "onewireio",
-    "paralleldisplay",
     "paralleldisplaybus",
     "picodvi",
+    "ps2io",
     "pulseio",
     "pwmio",
     "qrio",
+    "qspibus",
     "rainbowio",
+    "rclcpy",
     "rgbmatrix",
     "rotaryio",
     "rp2pio",
@@ -110,8 +133,9 @@ const CIRCUITPYTHON_CORE_MODULES = new Set([
     "wifi",
     "zlib",
 
-    // Bare-named community modules without the `adafruit_` prefix that are
-    // common enough to be worth recognising explicitly.
+    // Bare-named community modules without the `adafruit_` or
+    // `circuitpython_` prefix that are common enough to recognise
+    // explicitly.
     "neopixel",
     "simpleio",
 ]);

--- a/js/common/circuitpython_highlight.js
+++ b/js/common/circuitpython_highlight.js
@@ -117,12 +117,20 @@ const CIRCUITPYTHON_CORE_MODULES = new Set([
 ]);
 
 // Returns true when `name` is a CircuitPython module worth highlighting.
-// Wildcard-matches anything starting with `adafruit_` so new libraries
-// (e.g. `adafruit_foo_bar` shipped next month) light up automatically
-// without touching this file.
+// Wildcard-matches anything starting with `adafruit_` (Adafruit-maintained
+// libraries) or `circuitpython_` (community bundle libraries) so new
+// libraries light up automatically without touching this file. Both
+// prefixes are distinctive enough that false positives against ordinary
+// Python code are essentially nil.
 function isCircuitPythonModule(name) {
     if (CIRCUITPYTHON_CORE_MODULES.has(name)) return true;
     if (name.startsWith("adafruit_") && name.length > "adafruit_".length) {
+        return true;
+    }
+    if (
+        name.startsWith("circuitpython_") &&
+        name.length > "circuitpython_".length
+    ) {
         return true;
     }
     return false;

--- a/js/common/circuitpython_highlight.js
+++ b/js/common/circuitpython_highlight.js
@@ -133,9 +133,9 @@ const CIRCUITPYTHON_CORE_MODULES = new Set([
     "wifi",
     "zlib",
 
-    // Bare-named community modules without the `adafruit_` or
-    // `circuitpython_` prefix that are common enough to recognise
-    // explicitly.
+    // Early Adafruit-maintained libraries that predate the `adafruit_`
+    // naming convention and shipped without a prefix. Listed explicitly
+    // because the prefix wildcard below can't catch them.
     "neopixel",
     "simpleio",
 ]);

--- a/js/script.js
+++ b/js/script.js
@@ -5,6 +5,7 @@ import { indentWithTab } from "@codemirror/commands"
 import { python } from "@codemirror/lang-python";
 import { syntaxHighlighting, indentUnit } from "@codemirror/language";
 import { classHighlighter } from "@lezer/highlight";
+import { circuitpythonHighlight } from "./common/circuitpython_highlight.js";
 import { getFileIcon } from "./common/file_dialog.js";
 
 import { Terminal } from '@xterm/xterm';
@@ -405,6 +406,7 @@ const editorExtensions = [
     python(),
     editorTheme,
     syntaxHighlighting(classHighlighter),
+    circuitpythonHighlight,
     EditorView.updateListener.of(onTextChange)
 ];
 

--- a/sass/layout/_themes.scss
+++ b/sass/layout/_themes.scss
@@ -174,4 +174,11 @@
     .tok-bool {
         color: #E06C75;
     }
+
+    // CircuitPython-specific module names (overlay added by
+    // js/common/circuitpython_highlight.js). Distinct from regular
+    // variableName so users can spot CircuitPython modules at a glance.
+    .tok-cp-module {
+        color: #FF79C6;
+    }
 }

--- a/sass/layout/_themes.scss
+++ b/sass/layout/_themes.scss
@@ -176,8 +176,9 @@
     }
 
     // CircuitPython-specific module names (overlay added by
-    // js/common/circuitpython_highlight.js). Distinct from regular
-    // variableName so users can spot CircuitPython modules at a glance.
+    // js/common/circuitpython_highlight.js). The overlay extension is
+    // wrapped with Prec.highest so its decoration nests inside the
+    // classHighlighter span, letting this color win without !important.
     .tok-cp-module {
         color: #FF79C6;
     }


### PR DESCRIPTION
Related to #363 (held open until beta features merge to main).

Targets the `beta` branch.

## Approach

CodeMirror 6 dropped the simple `extra_keywords` mechanism that CM5 had, so instead of forking `@codemirror/lang-python` (and tracking it forever) this layers a small `ViewPlugin` on top of the existing Python syntax tree.

The plugin walks the visible `syntaxTree`, finds `VariableName` nodes whose text matches a known CircuitPython core module or common Adafruit library, and tags them with class `tok-cp-module` so the theme can color them distinctly.

## Files

- **New:** `js/common/circuitpython_highlight.js` — the overlay extension.
- **Edited:** `js/script.js` — adds `circuitpythonHighlight` to `editorExtensions`.
- **Edited:** `sass/layout/_themes.scss` — adds `.tok-cp-module` rule with a magenta accent (`#FF79C6`).

## Module list

~125 names: all CircuitPython core modules (`board`, `digitalio`, `displayio`, `busio`, `wifi`, `synthio`, `keypad`, `pulseio`, `pwmio`, `usb_cdc`, `usb_hid`, `usb_midi`, etc.) plus the most common `adafruit_*` libraries plus `neopixel` and `simpleio`. The list lives in one `Set` at the top of the new file — easy to extend or trim.

## Why this approach

- ✅ No upstream maintenance burden — Python language stays stock, no fork of `@codemirror/lang-python`.
- ✅ Only marks identifier nodes (`VariableName`), so strings and comments are never miscolored.
- ✅ Cheap — decoration set is rebuilt only on doc/viewport/tree changes, and only visible ranges are walked.
- ✅ Zero new dependencies; uses `@codemirror/view` and `@codemirror/language` already in the tree.

## Trade-offs / future work

- Limited to bare identifier matching for now. To highlight CircuitPython-specific attributes (e.g. `board.D13`) we'd extend the same overlay to `PropertyName` nodes — easy follow-up.
- The module list is hand-maintained. Adding a name when a new core module ships is a one-line change.

## Test

- `npm run build` is clean.
- New class `tok-cp-module` ships in `dist/assets/index.css`.
- Verified the dev server starts and the editor renders Python files normally with the extension active.

