### PR TITLE
Fix hang on connect with a read-only filesystem (#327)

### DIFF
--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -309,7 +309,11 @@ class USBWorkflow extends Workflow {
             await this.writer.ready;
         }
 
-        this.updateConnected(CONNSTATE.connected);
+        // Mark as partially connected: serial is open but the file client is not yet
+        // initialized. We must not advertise CONNSTATE.connected here because callers
+        // (e.g., save handlers) check connectionStatus() and will dereference fileHelper
+        // before initFileClient() has run. See issue #327.
+        this.updateConnected(CONNSTATE.partial);
 
         // At this point we should see if we should init the file client and check if have a saved dir handle
         let fileops = new FileOps(this.repl, false);
@@ -334,6 +338,10 @@ class USBWorkflow extends Workflow {
             } else {
                 console.log("Failed to load directory");
             }
+            // Note: in the read-only path we remain at CONNSTATE.partial until the user
+            // confirms a working host folder via _useHostFolder(), which calls onConnected().
+            // This ensures save/open attempts triggered before folder selection re-open
+            // the connect dialog instead of dereferencing a half-initialized fileHelper.
         } else {
             // File System is writable, so we can use the REPL File Transfer Client
             this.initFileClient(new ReplFileTransferClient(this.connectionStatus.bind(this), this.repl));

--- a/js/workflows/workflow.js
+++ b/js/workflows/workflow.js
@@ -156,7 +156,10 @@ except ImportError:
             return this._connected != CONNSTATE.disconnected;
         }
 
-        return this._connected == CONNSTATE.connected;
+        // Require both the connection state flag and an initialized fileHelper.
+        // This guards against a race where the underlying transport reports
+        // "connected" before the file client has been wired up (see #327).
+        return this._connected == CONNSTATE.connected && this.fileHelper != null;
     }
 
     async deinit() {
@@ -263,14 +266,17 @@ except ImportError:
     }
 
     async saveFile(path = null) {
-        if (path === null) {
-            if (this.currentFilename !== null) {
+        if (path == null) {
+            if (this.currentFilename != null) {
                 path = this.currentFilename;
             } else {
                 path = await this.saveFileAs();
             }
         }
-        if (path !== null) {
+        // Use loose equality so an undefined return from saveFileAs (e.g., dialog
+        // canceled or rejected) is treated the same as null and does not get
+        // forwarded to writeFile, where it would crash in _splitPath. See #327.
+        if (path != null) {
             await this._saveFileContents(path);
             return true;
         }
@@ -279,14 +285,16 @@ except ImportError:
 
     async saveFileAs() {
         let path = await this.saveFileDialog();
-        if (path !== null) {
-            // check if filename exists
-            if (path != this.currentFilename && await this.fileExists(path) && !window.confirm("Overwrite existing file '" + path + "'?")) {
-                return null;
-            }
-            this.currentFilename = path;
-            await this.saveFile(path);
+        // Normalize undefined to null so callers can use a single check.
+        if (path == null) {
+            return null;
         }
+        // check if filename exists
+        if (path != this.currentFilename && await this.fileExists(path) && !window.confirm("Overwrite existing file '" + path + "'?")) {
+            return null;
+        }
+        this.currentFilename = path;
+        await this.saveFile(path);
         return path;
     }
 


### PR DESCRIPTION
Closes #327.

Targeted at `main` since this is a bug fix; `beta` is reserved for features/enhancements and will pick this up on the next sync.

## Symptom

When connecting to a CircuitPython board whose filesystem is mounted read-only (e.g. CIRCUITPY is mounted on the host so CircuitPython itself can't write), pressing **Save** or **Save As** would hang the editor and log one of:

- `TypeError: Cannot read properties of null (reading 'readOnly')` — from `FileDialog.open`
- `TypeError: Cannot read properties of undefined (reading 'split')` — from `FSAPIFileTransferClient._splitPath`

## Root cause

USB connection is intentionally **two-part**: serial first, then file system (`CONNSTATE.partial` → `CONNSTATE.connected`). The code was promoting the workflow straight to `CONNSTATE.connected` immediately after `serialDevice.open()`, **before**:

1. the slow `fileops.isReadOnly()` REPL probe finished, and
2. `initFileClient(...)` had wired up `this.fileHelper`.

During that window:

- `connectionStatus()` returned `true`
- `this.fileHelper` was still `null`
- Any save (button or Cmd+S) would call `saveFileDialog` → `FileDialog.open(this.fileHelper, ...)` → `this._fileHelper.readOnly()` on `null`.

Separately, `saveFile`'s null check used strict `!== null`, so an `undefined` return from a canceled `saveFileDialog` slipped through and got passed all the way down to `_splitPath(undefined)`.

## Fix

Three small, coordinated changes:

### `js/workflows/usb.js`

- After `serialDevice.open()`, set `CONNSTATE.partial` instead of `CONNSTATE.connected`.
- Let `onConnected()` (writable / REPL branch) and `_useHostFolder()` (read-only / FSAPI branch) be the only places that promote the workflow to `CONNSTATE.connected`. Both already run *after* the file client is in place, which matches the existing two-part connection design.

### `js/workflows/workflow.js`

- `connectionStatus()`: in the strict (default) mode, also require `fileHelper != null`. Defensive guard against any future state-machine slips.
- `saveFile()`: use loose `== null` so `undefined` is treated like `null`. Add a comment explaining why.
- `saveFileAs()`: normalize `undefined` from the dialog to `null` early so callers don't have to handle both.

## User-visible behavior change

When the user is in the partial-connected state (serial open, file system not yet usable), save/open attempts now fall through to the existing `checkConnected()` → `workflow.showConnect()` path and re-open the connection dialog, instead of crashing. This matches @makermelissa's stated UX intent: *if a board is not (fully) connected, the connection dialog should come up when an operation that needs a connection is attempted.*

## Testing

- `npx vite build` succeeds locally on this branch.
- A hardware smoke test on a Pico with CIRCUITPY mounted is recommended before merge.

## Out of scope

- The `InvalidStateError: ... state had changed since it was read from disk` from FSAPI permission expiry mentioned in the issue. Probably needs re-querying `requestPermission` before write, or catch-and-retry. Worth its own focused PR.
- General connect/disconnect button state-machine cleanup tracked in #373.