### PR TITLE
Use /fs/ JSON 'writable' flag for read-only detection (closes #412)

### DIFF
--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -7,7 +7,11 @@ class FileTransferClient {
 
     async readOnly() {
         await this._checkConnection();
-        return !this._allowedMethods.includes('DELETE');
+        console.log("Checking read only");
+        const response = await this._fetch("/fs/", {method: "GET", headers: {"Accept": "application/json"}})
+        const result = await response.json();
+        //TODO: Tyeth: cache this value until reconnection, as listdir / connect already fetch it
+        return result.writable === undefined || result.writable === false || !this._allowedMethods.includes("DELETE");
     }
 
     async _checkConnection() {
@@ -15,6 +19,7 @@ class FileTransferClient {
             throw new Error("Unable to perform file operation. Not Connected.");
         }
 
+        //TODO: Tyeth: reset this on reconnection
         if (this._allowedMethods === null) {
             const status = await this._fetch("/fs/", {method: "OPTIONS"});
             this._allowedMethods = status.headers.get("Access-Control-Allow-Methods").split(/,/).map(method => {return method.trim().toUpperCase();});

--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -3,15 +3,25 @@ class FileTransferClient {
         this.hostname = hostname;
         this.connectionStatus = connectionStatusCB;
         this._allowedMethods = null;
+        // Cached `writable` flag from the /fs/ JSON response. Populated by
+        // listDir() and by readOnly() when listDir hasn't been called yet.
+        // A new FileTransferClient is created on every (re)connect, so this
+        // cache resets naturally with the connection lifecycle.
+        this._writable = null;
     }
 
     async readOnly() {
         await this._checkConnection();
-        console.log("Checking read only");
-        const response = await this._fetch("/fs/", {method: "GET", headers: {"Accept": "application/json"}})
-        const result = await response.json();
-        //TODO: Tyeth: cache this value until reconnection, as listdir / connect already fetch it
-        return result.writable === undefined || result.writable === false || !this._allowedMethods.includes("DELETE");
+        // Older CircuitPython releases advertised DELETE in OPTIONS even when
+        // the filesystem was actually read-only (USB had it), so we use the
+        // `writable` field from the /fs/ JSON response instead -- same source
+        // of truth as circup. If we already pulled it via listDir, reuse it.
+        if (this._writable === null) {
+            const response = await this._fetch("/fs/", {method: "GET", headers: {"Accept": "application/json"}});
+            const result = await response.json();
+            this._writable = result.writable === true;
+        }
+        return !this._writable;
     }
 
     async _checkConnection() {
@@ -19,7 +29,6 @@ class FileTransferClient {
             throw new Error("Unable to perform file operation. Not Connected.");
         }
 
-        //TODO: Tyeth: reset this on reconnection
         if (this._allowedMethods === null) {
             const status = await this._fetch("/fs/", {method: "OPTIONS"});
             this._allowedMethods = status.headers.get("Access-Control-Allow-Methods").split(/,/).map(method => {return method.trim().toUpperCase();});
@@ -136,7 +145,12 @@ class FileTransferClient {
 
         const response = await this._fetch(`/fs${path}`, {headers: {"Accept": "application/json"}});
         const results = await response.json();
-        let listings = results
+        // Cache the writable flag whenever the FS root response carries it,
+        // so readOnly() doesn't need a separate round-trip.
+        if (results.writable !== undefined) {
+            this._writable = results.writable === true;
+        }
+        let listings = results;
         if (results.files !== undefined) {
             listings = results.files;
         }


### PR DESCRIPTION
Picks up #412 (originally by @tyeth, who is no longer working on it — see [this comment](https://github.com/circuitpython/web-editor/pull/412#issuecomment-4306554321)) and addresses both of the TODOs left in the diff.

## Problem

`FileTransferClient.readOnly()` was deciding whether the board's filesystem was writable by inspecting whether `DELETE` showed up in the `Access-Control-Allow-Methods` header from a preflight `OPTIONS /fs/` call.

On CircuitPython 10.0.3 (reproduced by @tyeth on a LilyGo T-Display S3) `DELETE` is advertised even when USB has claimed the filesystem. The web editor therefore thought the device was writable, sent a `PUT`, and the board responded with a free-form `USB ACTIVE, try resetting board` body that wasn't surfaced anywhere — so saves silently failed.

## Fix

Switch to the same source of truth `circup` uses: the `writable` boolean in the `/fs/` JSON response.

- **`readOnly()`** uses a cached `_writable` flag and only falls back to a fresh `GET /fs/` (`Accept: application/json`) when the cache hasn't been populated yet.
- **`listDir()`** populates the cache for free whenever the FS-root response includes the flag, which is exactly the path the connect flow already takes (`web.js` calls `listDir('/')` immediately after constructing the client). In the typical hot path, `readOnly()` costs zero extra round-trips.
- The `DELETE`-in-OPTIONS heuristic is removed entirely.
- Both of @tyeth's `TODO` comments in the original PR are now obsolete and dropped: `_allowedMethods` and `_writable` reset naturally because `FileTransferClient` is reconstructed on every (re)connect.

## Notes

- The `usb.js` portion of the original #412 was rendered empty by the `try/catch` wrappers landed in #483, so it's not reapplied here.
- Tested locally with `npx vite build` (clean).

Closes #412.

Co-authored-by: tyeth &lt;tyethgundry@googlemail.com&gt;
