### PR TITLE
Honor save failures and surface USB-MSC hint when the filesystem is locked

### DIFF
--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -50,9 +50,36 @@ class FileTransferClient {
         }
     }
 
+    // Build a ProtocolError-shaped error that callers can recognize as
+    // "the device's filesystem is currently held by something else"
+    // (typically USB MSC). Tagged identically to the runtime PUT 409/500
+    // path so `saveFileContents()` can show the same actionable dialog
+    // whether the check trips on the cached writable flag or on the
+    // actual response from the device.
+    _writeProtectedError() {
+        const err = new ProtocolError("File System is Read Only.");
+        err.status = 409;
+        err.writeProtected = true;
+        err.hint = "The board's filesystem is currently locked, " +
+                   "usually because CIRCUITPY is mounted on a " +
+                   "computer over USB. Disconnect the USB cable, " +
+                   "or disable USB Mass Storage in boot.py, then " +
+                   "reset the board and try saving again. " +
+                   "(Ejecting the drive in your OS may not be " +
+                   "enough on its own.)";
+        err.helpUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
+        err.helpLabel = "Disabling USB Mass Storage (Adafruit Learn)";
+        return err;
+    }
+
     async _checkWritable() {
+        // Force a re-read of the writable flag so the user can recover
+        // without disconnecting: if they just released the drive (or
+        // disabled USB MSC and reset), the next save attempt should
+        // succeed, not bounce off a stale `false` cache.
+        this._writable = null;
         if (await this.readOnly()) {
-            throw new Error("File System is Read Only. Try disabling the USB Drive.");
+            throw this._writeProtectedError();
         }
     }
 
@@ -128,15 +155,6 @@ class FileTransferClient {
             err.status = response.status;
             err.method = (fetchOptions.method || "GET").toUpperCase();
             err.path = location;
-            // DEBUG: leave this in until we're sure the writeProtected
-            // detection is firing in the field. Cheap, runs only on
-            // non-OK responses.
-            console.warn("[web-file-transfer] non-OK response", {
-                method: err.method,
-                path: err.path,
-                status: err.status,
-                statusText: response.statusText,
-            });
             // /fs/ PUT against a write-protected filesystem currently returns
             // 500 on shipped CircuitPython firmware. A fix is pending to
             // return 409 Conflict (matching DELETE / MOVE / mkdir-PUT in
@@ -146,16 +164,14 @@ class FileTransferClient {
                               typeof location === "string" &&
                               location.startsWith("/fs/");
             if (isFsWrite && (response.status === 409 || response.status === 500)) {
+                // Reuse the same wording/hint as the cached-flag
+                // _checkWritable() path, so users see one consistent
+                // message regardless of which layer caught the lock.
+                const wp = this._writeProtectedError();
                 err.writeProtected = true;
-                err.hint = "The board's filesystem is currently locked, " +
-                           "usually because CIRCUITPY is mounted on a " +
-                           "computer over USB. Disconnect the USB cable, " +
-                           "or disable USB Mass Storage in boot.py, then " +
-                           "reset the board and try saving again. " +
-                           "(Ejecting the drive in your OS may not be " +
-                           "enough on its own.)";
-                err.helpUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
-                err.helpLabel = "Disabling USB Mass Storage (Adafruit Learn)";
+                err.hint = wp.hint;
+                err.helpUrl = wp.helpUrl;
+                err.helpLabel = wp.helpLabel;
             }
             throw err;
         }

--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -72,7 +72,8 @@ class FileTransferClient {
             options.headers['Content-Type'] = "application/octet-stream";
         }
 
-        await this._fetch(`/fs${path}`, options);
+        const response = await this._fetch(`/fs${path}`, options);
+        return response.ok;
     }
 
     // Makes the directory and any missing parents
@@ -120,7 +121,28 @@ class FileTransferClient {
         }
 
         if (!response.ok) {
-            throw new ProtocolError(response.statusText);
+            // Attach the status code + a friendly hint when we recognize
+            // the failure mode, so callers can branch on it (e.g. show an
+            // actionable message and skip retries that won't help).
+            const err = new ProtocolError(response.statusText || `HTTP ${response.status}`);
+            err.status = response.status;
+            err.method = (fetchOptions.method || "GET").toUpperCase();
+            err.path = location;
+            // /fs/ PUT against a write-protected filesystem currently returns
+            // 500 on shipped CircuitPython firmware. A fix is pending to
+            // return 409 Conflict (matching DELETE / MOVE / mkdir-PUT in
+            // the same file). Treat both the same way until enough users
+            // are on the patched firmware that 500 can be left generic.
+            const isFsWrite = err.method === "PUT" &&
+                              typeof location === "string" &&
+                              location.startsWith("/fs/");
+            if (isFsWrite && (response.status === 409 || response.status === 500)) {
+                err.writeProtected = true;
+                err.hint = "CIRCUITPY may be mounted on your computer. " +
+                           "Eject it (or disable USB Mass Storage in boot.py) " +
+                           "and try again.";
+            }
+            throw err;
         }
 
         return response;

--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -145,6 +145,8 @@ class FileTransferClient {
                            "reset the board and try saving again. " +
                            "(Ejecting the drive in your OS may not be " +
                            "enough on its own.)";
+                err.helpUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
+                err.helpLabel = "Disabling USB Mass Storage (Adafruit Learn)";
             }
             throw err;
         }

--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -138,9 +138,13 @@ class FileTransferClient {
                               location.startsWith("/fs/");
             if (isFsWrite && (response.status === 409 || response.status === 500)) {
                 err.writeProtected = true;
-                err.hint = "CIRCUITPY may be mounted on your computer. " +
-                           "Eject it (or disable USB Mass Storage in boot.py) " +
-                           "and try again.";
+                err.hint = "The board's filesystem is currently locked, " +
+                           "usually because CIRCUITPY is mounted on a " +
+                           "computer over USB. Disconnect the USB cable, " +
+                           "or disable USB Mass Storage in boot.py, then " +
+                           "reset the board and try saving again. " +
+                           "(Ejecting the drive in your OS may not be " +
+                           "enough on its own.)";
             }
             throw err;
         }

--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -128,6 +128,15 @@ class FileTransferClient {
             err.status = response.status;
             err.method = (fetchOptions.method || "GET").toUpperCase();
             err.path = location;
+            // DEBUG: leave this in until we're sure the writeProtected
+            // detection is firing in the field. Cheap, runs only on
+            // non-OK responses.
+            console.warn("[web-file-transfer] non-OK response", {
+                method: err.method,
+                path: err.path,
+                status: err.status,
+                statusText: response.statusText,
+            });
             // /fs/ PUT against a write-protected filesystem currently returns
             // 500 on shipped CircuitPython firmware. A fix is pending to
             // return 409 Conflict (matching DELETE / MOVE / mkdir-PUT in

--- a/js/script.js
+++ b/js/script.js
@@ -595,6 +595,22 @@ async function saveFileContents(path) {
             } catch (e) {
                 console.error(`write failed (attempt ${attempt} of ${MAX_SAVE_RETRIES})`, e, e.stack);
                 unchanged = Math.min(baseUnchanged, unchanged);
+                // If the device cleanly told us the filesystem is held by
+                // someone else (most commonly USB-MSC: the host has
+                // CIRCUITPY mounted), retrying won't help -- surface an
+                // actionable hint immediately and bail. Older CircuitPython
+                // firmware returns 500 for this case, newer firmware
+                // returns 409 Conflict; web-file-transfer.js tags both
+                // with `writeProtected` so we can treat them the same way.
+                if (e && e.writeProtected) {
+                    setSaved(false);
+                    const hint = e.hint || "The filesystem is currently read-only.";
+                    await showMessage(
+                        `Saving file '${workflow.currentFilename}' failed: ${hint} ` +
+                        `Your edits are still in the editor -- save again once the drive is released.`
+                    );
+                    return false;
+                }
                 if (attempt < MAX_SAVE_RETRIES) {
                     await sleep(SAVE_RETRY_DELAY_MS);
                     // Bail out if the user disconnected mid-retry.

--- a/js/script.js
+++ b/js/script.js
@@ -594,6 +594,14 @@ async function saveFileContents(path) {
                 return false;
             } catch (e) {
                 console.error(`write failed (attempt ${attempt} of ${MAX_SAVE_RETRIES})`, e, e.stack);
+                console.warn("[saveFileContents] caught error fields", {
+                    name: e && e.name,
+                    message: e && e.message,
+                    status: e && e.status,
+                    method: e && e.method,
+                    path: e && e.path,
+                    writeProtected: e && e.writeProtected,
+                });
                 unchanged = Math.min(baseUnchanged, unchanged);
                 // If the device cleanly told us the filesystem is held by
                 // someone else (most commonly USB-MSC: the host has

--- a/js/script.js
+++ b/js/script.js
@@ -605,8 +605,16 @@ async function saveFileContents(path) {
                 if (e && e.writeProtected) {
                     setSaved(false);
                     const hint = e.hint || "The filesystem is currently read-only.";
+                    let helpLink = "";
+                    if (e.helpUrl) {
+                        const label = e.helpLabel || "More info";
+                        // MessageModal renders via innerHTML, so a real <a>
+                        // tag is clickable. target=_blank + noopener so we
+                        // don't nav away from the editor.
+                        helpLink = ` <a href="${e.helpUrl}" target="_blank" rel="noopener noreferrer">${label}</a>.`;
+                    }
                     await showMessage(
-                        `Saving file '${workflow.currentFilename}' failed. ${hint} ` +
+                        `Saving file '${workflow.currentFilename}' failed. ${hint}${helpLink} ` +
                         `Your edits are still here in the editor -- save again once the board's filesystem is writable.`
                     );
                     return false;

--- a/js/script.js
+++ b/js/script.js
@@ -331,7 +331,19 @@ async function checkReadOnly() {
         await showMessage(readOnly);
         return false;
     } else if (readOnly) {
-        await showMessage("Warning: File System is in read only mode. Disable the USB drive to allow write access.");
+        // Same wording as the per-save dialog, with the Learn-guide
+        // link, so the very first popup users see at connect already
+        // points them at the right fix.
+        const learnUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
+        const learnLabel = "Disabling USB Mass Storage (Adafruit Learn)";
+        await showMessage(
+            "Warning: the board's filesystem is read-only, usually because " +
+            "CIRCUITPY is mounted on a computer over USB. You can browse and " +
+            "open files, but saving will fail until the lock is released. " +
+            "Disconnect the USB cable, or disable USB Mass Storage in boot.py, " +
+            "then reset the board. (Ejecting the drive in your OS may not be " +
+            `enough on its own.) <a href="${learnUrl}" target="_blank" rel="noopener noreferrer">${learnLabel}</a>.`
+        );
     }
     return true;
 }
@@ -594,14 +606,6 @@ async function saveFileContents(path) {
                 return false;
             } catch (e) {
                 console.error(`write failed (attempt ${attempt} of ${MAX_SAVE_RETRIES})`, e, e.stack);
-                console.warn("[saveFileContents] caught error fields", {
-                    name: e && e.name,
-                    message: e && e.message,
-                    status: e && e.status,
-                    method: e && e.method,
-                    path: e && e.path,
-                    writeProtected: e && e.writeProtected,
-                });
                 unchanged = Math.min(baseUnchanged, unchanged);
                 // If the device cleanly told us the filesystem is held by
                 // someone else (most commonly USB-MSC: the host has

--- a/js/script.js
+++ b/js/script.js
@@ -606,8 +606,8 @@ async function saveFileContents(path) {
                     setSaved(false);
                     const hint = e.hint || "The filesystem is currently read-only.";
                     await showMessage(
-                        `Saving file '${workflow.currentFilename}' failed: ${hint} ` +
-                        `Your edits are still in the editor -- save again once the drive is released.`
+                        `Saving file '${workflow.currentFilename}' failed. ${hint} ` +
+                        `Your edits are still here in the editor -- save again once the board's filesystem is writable.`
                     );
                     return false;
                 }

--- a/js/script.js
+++ b/js/script.js
@@ -331,18 +331,13 @@ async function checkReadOnly() {
         await showMessage(readOnly);
         return false;
     } else if (readOnly) {
-        // Same wording as the per-save dialog, with the Learn-guide
-        // link, so the very first popup users see at connect already
-        // points them at the right fix.
+        // Concise connect-time notice that the filesystem is read-only,
+        // with a link to the Learn guide for users who want the fix now.
         const learnUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
-        const learnLabel = "Disabling USB Mass Storage (Adafruit Learn)";
         await showMessage(
-            "Warning: the board's filesystem is read-only, usually because " +
-            "CIRCUITPY is mounted on a computer over USB. You can browse and " +
-            "open files, but saving will fail until the lock is released. " +
-            "Disconnect the USB cable, or disable USB Mass Storage in boot.py, " +
-            "then reset the board. (Ejecting the drive in your OS may not be " +
-            `enough on its own.) <a href="${learnUrl}" target="_blank" rel="noopener noreferrer">${learnLabel}</a>.`
+            "Filesystem is read-only — you can browse files, but saving " +
+            "will fail until USB Mass Storage is released. " +
+            `<a href="${learnUrl}" target="_blank" rel="noopener noreferrer">How to fix</a>.`
         );
     }
     return true;
@@ -616,18 +611,24 @@ async function saveFileContents(path) {
                 // with `writeProtected` so we can treat them the same way.
                 if (e && e.writeProtected) {
                     setSaved(false);
-                    const hint = e.hint || "The filesystem is currently read-only.";
-                    let helpLink = "";
-                    if (e.helpUrl) {
-                        const label = e.helpLabel || "More info";
-                        // MessageModal renders via innerHTML, so a real <a>
-                        // tag is clickable. target=_blank + noopener so we
-                        // don't nav away from the editor.
-                        helpLink = ` <a href="${e.helpUrl}" target="_blank" rel="noopener noreferrer">${label}</a>.`;
-                    }
+                    const learnUrl = e.helpUrl || "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
+                    const learnLabel = e.helpLabel || "Disabling USB Mass Storage (Adafruit Learn)";
+                    // MessageModal renders via innerHTML, so real markup
+                    // (sections, list, link) is fine. Sections separate the
+                    // 'what happened', 'why', and 'how to fix' so users can
+                    // scan instead of parsing a wall of prose.
                     await showMessage(
-                        `Saving file '${workflow.currentFilename}' failed. ${hint}${helpLink} ` +
-                        `Your edits are still here in the editor -- save again once the board's filesystem is writable.`
+                        `<p><strong>Could not save '${workflow.currentFilename}'.</strong></p>` +
+                        `<p>The board's filesystem is locked, usually because ` +
+                        `CIRCUITPY is mounted on a computer over USB.</p>` +
+                        `<p><strong>To fix:</strong></p>` +
+                        `<ul style="margin: 0.25em 0 0.5em 1.25em; padding: 0;">` +
+                            `<li>Disconnect the USB cable, <em>or</em></li>` +
+                            `<li>Disable USB Mass Storage in <code>boot.py</code>, then reset the board.</li>` +
+                        `</ul>` +
+                        `<p><em>Note:</em> ejecting the drive in your OS isn't always enough on its own.</p>` +
+                        `<p><a href="${learnUrl}" target="_blank" rel="noopener noreferrer">${learnLabel}</a></p>` +
+                        `<p>Your edits are still here — save again once the filesystem is writable.</p>`
                     );
                     return false;
                 }

--- a/js/script.js
+++ b/js/script.js
@@ -229,8 +229,11 @@ async function newFile() {
 
 async function saveRunFile() {
     if (await checkConnected()) {
+        // workflow.saveFile() now propagates the real save result -- only
+        // soft-restart / re-import once the PUT actually succeeded. Otherwise
+        // we would reboot the board running the old code.py while the editor
+        // still had the unsaved edits (issue #460).
         if (await workflow.saveFile()) {
-            setSaved(true);
             await workflow.runCurrentCode();
         }
     }
@@ -535,47 +538,80 @@ async function loadEditor() {
 }
 
 var editor;
-var currentTimeout = null;
-var saveRetryCount = 0;
 const MAX_SAVE_RETRIES = 3;
+const SAVE_RETRY_DELAY_MS = 2000;
+let saveInFlight = false;
 
-// Save the File Contents and update the UI
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Save the File Contents and update the UI. Returns true on success, false
+// on final failure (after all retries). Retries inline so callers (Save+Run,
+// hotkeys, dialogs) can actually await the outcome -- previously this used
+// a fire-and-forget setTimeout, which let Save+Run soft-restart the board
+// before the PUT had succeeded (issue #460).
 async function saveFileContents(path) {
-    // If this is a different file, we write everything
-    if (path !== workflow.currentFilename) {
-        unchanged = 0;
+    if (saveInFlight) {
+        // Re-entrant save (e.g. user mashing Ctrl-S / Save+Run). The first
+        // call will report success/failure; the second would race the same
+        // bytes onto the wire and confuse partialWrites bookkeeping.
+        console.log("saveFileContents: already in flight, ignoring re-entry");
+        return false;
     }
-    let doc = editor.state.doc;
-    let offset = 0;
-    let contents = doc.sliceString(0);
-    if (workflow.partialWrites) {
-        offset = unchanged;
-        console.log("sync starting at", unchanged, "to", editor.state.doc.length);
-    }
-    let oldUnchanged = unchanged;
-    unchanged = doc.length;
+    saveInFlight = true;
     try {
-        if (await workflow.writeFile(path, contents, offset)) {
-            setFilename(workflow.currentFilename);
-            setSaved(true);
-            saveRetryCount = 0;
-        } else {
-            await showMessage(`Saving file '${workflow.currentFilename}' failed.`);
+        // If this is a different file, we write everything
+        if (path !== workflow.currentFilename) {
+            unchanged = 0;
         }
-    } catch (e) {
-        console.error("write failed", e, e.stack);
-        unchanged = Math.min(oldUnchanged, unchanged);
-        if (currentTimeout != null) {
-            clearTimeout(currentTimeout);
+        let doc = editor.state.doc;
+        let contents = doc.sliceString(0);
+        let baseUnchanged = unchanged;
+        let docLengthAtStart = doc.length;
+
+        for (let attempt = 1; attempt <= MAX_SAVE_RETRIES; attempt++) {
+            // Recompute offset each attempt -- if onTextChange fired between
+            // retries, `unchanged` may have shrunk and we need to resend more.
+            let offset = 0;
+            if (workflow.partialWrites) {
+                offset = Math.min(baseUnchanged, unchanged);
+                console.log("sync starting at", offset, "to", editor.state.doc.length);
+            }
+            // Optimistically mark the bytes-being-sent as unchanged. If the
+            // write throws we'll roll back to baseUnchanged for the next try.
+            unchanged = docLengthAtStart;
+            try {
+                if (await workflow.writeFile(path, contents, offset)) {
+                    setFilename(workflow.currentFilename);
+                    setSaved(true);
+                    return true;
+                }
+                // writeFile returned a falsy value without throwing -- treat
+                // as a soft failure and surface a message immediately.
+                await showMessage(`Saving file '${workflow.currentFilename}' failed.`);
+                setSaved(false);
+                return false;
+            } catch (e) {
+                console.error(`write failed (attempt ${attempt} of ${MAX_SAVE_RETRIES})`, e, e.stack);
+                unchanged = Math.min(baseUnchanged, unchanged);
+                if (attempt < MAX_SAVE_RETRIES) {
+                    await sleep(SAVE_RETRY_DELAY_MS);
+                    // Bail out if the user disconnected mid-retry.
+                    if (!workflow || !workflow.connectionStatus()) {
+                        setSaved(false);
+                        return false;
+                    }
+                }
+            }
         }
-        saveRetryCount++;
-        if (saveRetryCount < MAX_SAVE_RETRIES) {
-            console.log(`Save retry ${saveRetryCount} of ${MAX_SAVE_RETRIES}...`);
-            currentTimeout = setTimeout(() => saveFileContents(path), 2000);
-        } else {
-            saveRetryCount = 0;
-            await showMessage(`Saving file '${workflow.currentFilename}' failed after multiple attempts. Check your connection and try again.`);
-        }
+        // All retries exhausted. Leave the editor marked dirty so the user
+        // knows the file on the board is still stale.
+        setSaved(false);
+        await showMessage(`Saving file '${workflow.currentFilename}' failed after multiple attempts. Check your connection and try again.`);
+        return false;
+    } finally {
+        saveInFlight = false;
     }
 }
 
@@ -611,19 +647,13 @@ async function onTextChange(update) {
         unchanged = 0;
     }
 
-    if (currentTimeout != null) {
-        clearTimeout(currentTimeout);
-    }
-
     setSaved(false);
 }
 
 function disconnectCallback() {
-    if (currentTimeout != null) {
-        clearTimeout(currentTimeout);
-        currentTimeout = null;
-    }
-    saveRetryCount = 0;
+    // saveInFlight is intentionally not forced here -- the in-flight
+    // saveFileContents loop checks connectionStatus() between retries and
+    // exits cleanly on its own, then clears the flag in its finally block.
     updateUIConnected(false);
 }
 

--- a/js/workflows/workflow.js
+++ b/js/workflows/workflow.js
@@ -442,8 +442,14 @@ except ImportError:
         // canceled or rejected) is treated the same as null and does not get
         // forwarded to writeFile, where it would crash in _splitPath. See #327.
         if (path != null) {
-            await this._saveFileContents(path);
-            return true;
+            // Propagate the actual save result so Save+Run and other callers
+            // can avoid taking follow-up actions (soft-restart, import) when
+            // the underlying PUT failed. _saveFileContents returns false on
+            // exhausted retries; treating only an explicit `false` as failure
+            // keeps backwards compatibility with older saveFileFunc callbacks
+            // that returned undefined on success (issue #460).
+            const result = await this._saveFileContents(path);
+            return result !== false;
         }
         return false;
     }

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -318,7 +318,32 @@
     display: none;
 
     &.prompt {
-        max-height: 365px;
+        max-height: 80vh;
+        // Flex column so the buttons stay pinned to the bottom and the
+        // content area can scroll when a dialog has rich/multi-section
+        // markup that overflows the modal height. Three-class selector
+        // beats `.popup-modal.is--visible` so the `display: flex`
+        // wins on specificity.
+        &.is--visible {
+            display: flex;
+            flex-direction: column;
+        }
+        #message {
+            overflow-y: auto;
+            flex: 1 1 auto;
+            min-height: 0;
+        }
+        .buttons {
+            flex: 0 0 auto;
+        }
+    }
+
+    // The message dialog often shows multi-section explanatory prose
+    // (e.g. the save-failure / read-only-filesystem help). Cap the
+    // width so paragraphs wrap at a comfortable reading measure rather
+    // than stretching the full viewport on a wide monitor.
+    &[data-popup-modal="message"] {
+        max-width: min(480px, 90vw);
     }
 
     &.shadow {


### PR DESCRIPTION
## Summary

Fixes #460 — "Cannot Save code.py Edits on Adafruit Qualia ESP32-S3."

The root cause, after walking through the firmware code, is that **the
board's filesystem is write-locked by USB Mass Storage**: when the host
computer has CIRCUITPY mounted, CircuitPython can't write through FatFS
even though the web workflow happily accepts the request. The current
firmware reports this as `HTTP 500 Internal Server Error`, which looks
like a server crash and gave the editor nothing actionable to show.
Confirmed by repro: the failure disappears the moment USB MSC is
disabled in `boot.py`.

This PR fixes the editor's behavior in three ways:

1. **Stop pretending failed saves succeeded.** The previous
   `saveFileContents()` retried via a fire-and-forget `setTimeout`, so
   `workflow.saveFile()` returned `true` immediately while retries ran
   in the background. `saveRunFile()` then soft-restarted the board
   while the PUT hadn't actually landed yet, running the previously
   saved `code.py`.
2. **Show an actionable hint** when the device tells us the filesystem
   is locked, instead of the generic "failed after multiple attempts."
3. **Skip pointless retries** when the failure is "host owns the disk"
   — retrying can't help until the user ejects.

A companion firmware PR ([adafruit/circuitpython#11017](https://github.com/adafruit/circuitpython/pull/11017))
brings the file-writing PUT in line with DELETE / MOVE / mkdir-PUT in
the same file, which already reply `409 Conflict` for
`FR_WRITE_PROTECTED`. The editor handles both `500` (old firmware) and
`409` (new firmware) the same way, so users on any CP version benefit
from the better error message.

## Root cause

The prior PR #472 capped the runaway retry loop (the "editor reloads
every 1-2 seconds" symptom) but the deeper bug was still there:

- `saveFileContents()` retried via `setTimeout(saveFileContents, 2000)`
  inside the catch block.
- The outer call returned normally, so `workflow.saveFile()`
  unconditionally returned `true`.
- `saveRunFile()` saw a truthy result and called
  `workflow.runCurrentCode()` → `repl.softRestart()`.
- The board rebooted into the OLD `code.py` while retries fired against
  a rebooting device, all failed, and the editor showed
  "Saving file failed after multiple attempts" — but had already
  flipped its UI back to "saved," so the unsaved buffer was lost too.

Two bugs stacked: a misleading server response from the firmware AND
the editor lying about save success to the rest of the app.

## Changes

### `js/script.js`

- `saveFileContents()` is now a real awaitable retry loop:
  - 3 attempts, 2 s apart, using `await sleep(...)` instead of
    fire-and-forget `setTimeout`.
  - Returns `true` on success, `false` on exhausted retries (or on
    disconnect mid-retry).
  - `saveInFlight` flag refuses re-entrant invocations so mashing
    Ctrl-S / Save+Run doesn't race two PUTs onto the wire and corrupt
    `partialWrites` bookkeeping.
  - On any failure the editor stays marked dirty (`setSaved(false)`),
    so the unsaved buffer is recoverable.
  - **New: when the device cleanly says the filesystem is held by
    someone else (`409 Conflict` or `500 Internal Server Error` on a
    `/fs/` PUT), skip the remaining retries and show:**
    > **Could not save '/code.py'.**
    >
    > The board's filesystem is locked, usually because CIRCUITPY is
    > mounted on a computer over USB.
    >
    > **To fix:**
    >
    > - Disconnect the USB cable, *or*
    > - Disable USB Mass Storage in `boot.py`, then reset the board.
    >
    > *Note:* ejecting the drive in your OS isn't always enough on its own.
    >
    > [Disabling USB Mass Storage (Adafruit Learn)][learn-msc]
    >
    > Your edits are still here — save again once the filesystem is writable.

    [learn-msc]: https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964

    The dialog renders headers, list, and link via real HTML
    (`MessageModal` uses `innerHTML`), so it scans cleanly instead of
    being a wall of prose.

    The corresponding connect-time read-only warning was shortened
    to a single line so it doesn't shout at every connect:

    > Filesystem is read-only — you can browse files, but saving
    > will fail until USB Mass Storage is released.
    > [How to fix][learn-msc].

    (The "eject may not be enough" caveat reflects real-world
    behavior on macOS: Finder's Eject command sometimes unmounts the
    filesystem locally without sending the SCSI `START_STOP_UNIT`
    eject command, so the device-side `blockdev_unlock()` never
    fires and `STA_PROTECT` stays set.)

- `saveRunFile()` drops the redundant `setSaved(true)`;
  `saveFileContents()` already handles it on success, and we only
  reach `runCurrentCode()` when the save actually worked.
- `disconnectCallback()` no longer juggles a retry timeout — the
  inline loop owns its own state now and bails out cleanly when
  `connectionStatus()` flips false between attempts.

### `js/workflows/workflow.js`

- `saveFile()` propagates the real result from `_saveFileContents()`
  instead of unconditionally returning `true`. Uses `result !== false`
  so any legacy `saveFileFunc` callback returning `undefined` still
  counts as success.

### `js/common/web-file-transfer.js`

- `_fetch()` attaches numeric status, method, and path to the thrown
  `ProtocolError`, and tags `/fs/` PUT failures with status `409` or
  `500` as `writeProtected = true` with a human-readable `hint`.
  Additive — callers that ignore the new fields get the same
  `ProtocolError` they used to.
- `writeFile()` returns `response.ok` so the workflow layer sees real
  success / failure (matches what `makeDir()` already does).

## Behavior after the fix

| Scenario | Before | After |
| --- | --- | --- |
| PUT succeeds first try | UI marks saved ✅ | UI marks saved ✅ |
| Host has CIRCUITPY mounted (current firmware → 500) | "Failed after multiple attempts" after ~6s of retries; board soft-restarted with stale code ❌ | Immediate "unplug USB / disable USB MSC in boot.py" message; no retries; no soft-restart ✅ |
| Host has CIRCUITPY mounted (with #11017 → 409) | n/a | Same as above ✅ |
| Transient network glitch | Retries 2× (sometimes worked, sometimes restarted before completion) | Retries 2× inline; Save+Run waits for real success ✅ |
| Persistent network failure | UI flipped to "saved," unsaved buffer lost, soft-restart anyway ❌ | Editor stays dirty, no restart, generic error dialog, buffer recoverable ✅ |
| User mashes Ctrl-S during save | Two overlapping PUTs, partialWrites offsets confused | Second call no-ops with a console message |
| Disconnect mid-retry | `disconnectCallback` had to clean up a global timeout | Inline loop notices `!connectionStatus()` and bails |

## Why detect both 409 and 500

CircuitPython firmware versions that ship today return `500` for the
write-protected case. The companion firmware PR
([adafruit/circuitpython#11017](https://github.com/adafruit/circuitpython/pull/11017))
will return `409 Conflict` to match the rest of the web workflow's
error contract. **Users will be on mixed firmware versions for years**,
so the editor handles both the same way. The detection is gated on
the request being a `PUT` to `/fs/`, so generic 500s elsewhere are
unaffected.

## Testing

- `npm run build` (vite) passes clean.
- `node --check` on all edited files passes.
- Manual reproduction:
  - **Before:** Mount CIRCUITPY on host, hit Save+Run → editor showed
    "Saving file failed after multiple attempts," board soft-restarted
    with stale code.
  - **After:** Same flow → immediate "Eject CIRCUITPY / disable USB
    MSC in boot.py" message, no soft-restart, buffer stays in the
    editor.
  - With USB MSC disabled in `boot.py`: save works on the first try
    as expected.
- Manually traced BLE (`partialWrites=true`), web workflow
  (`partialWrites=false`), `checkSaved()` unsaved dialog, and the
  Ctrl-S / Save+Run / Mod-r hotkey paths through the refactored code.

Refs adafruit/circuitpython#11017

Closes #460
