### PR TITLE
Note Firefox 151 support in Web Serial unavailable message

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,9 +316,8 @@
                 <div class="step-number"></div>
                 <div class="step-content">
                     <h1>Web Serial not available!</h1>
-                    <p>Web Serial is currently only supported in Chromium-based browsers.</p>
-                    <p>For versions of Google Chrome between versions 78-89, Web Serial needs to manually be enabled. On recent browsers, this feature is enabled by default. If you are on an older version of the browser,
-                        you may be able to enable Web Serial with the
+                    <p>Web Serial is supported in Chromium-based browsers (Chrome, Edge, Opera, etc.) and in Firefox 151 or later on desktop.</p>
+                    <p>On a recent Chromium-based browser or Firefox 151+, this feature is enabled by default &mdash; please make sure your browser is up to date. For versions of Google Chrome between 78 and 89, you may be able to enable Web Serial with the
                         <a href="about://flags/#enable-experimental-web-platform-features">about://flags/#enable-experimental-web-platform-features</a>
                         flag.</p>
                     </div>


### PR DESCRIPTION
## Summary

Firefox 151 (released 2026-05-19) added support for the Web Serial API on desktop, enabled by default. The editor's "Web Serial not available!" modal still tells users that Web Serial is Chromium-only, which is now out of date.

This PR updates the modal copy in `index.html` so users on Firefox 151+ know they're on a supported browser. Tested on Firefox 150 (correctly shows the message) and Firefox 151 (skips the message and proceeds to the port-selection step), so the underlying `'serial' in navigator` feature-detection in `js/workflows/usb.js` already does the right thing &mdash; only the user-facing copy needed updating.

## Changes

- Reword the "Web Serial not available!" body in `index.html` to list Chromium-based browsers **and** Firefox 151+ desktop as supported.
- Keep the existing `chrome://flags` hint for the older Chrome 78&ndash;89 window.
- Web Bluetooth message is intentionally left alone (Firefox still doesn't implement Web Bluetooth).

## References

- Mozilla Hacks: [Announcing Web Serial Support in Firefox](https://hacks.mozilla.org/2026/05/web-serial-support-in-firefox/) (Firefox 151, 2026-05-19)
- Mozilla blog: [Mozilla and Adafruit bring Web Serial workflows to Firefox](https://blog.mozilla.org/en/firefox/firefox-web-serial-adafruit/)

## Test plan

- `npx vite build` succeeds.
- Manually verified on Firefox 150 (sees the not-available message, with updated copy) and Firefox 151 (proceeds past the message into port selection).