### PR TITLE
Broaden read-only filesystem messaging to cover non-host-mounted cases (refs #460)

### DIFF
--- a/js/common/web-file-transfer.js
+++ b/js/common/web-file-transfer.js
@@ -60,13 +60,20 @@ class FileTransferClient {
         const err = new ProtocolError("File System is Read Only.");
         err.status = 409;
         err.writeProtected = true;
-        err.hint = "The board's filesystem is currently locked, " +
-                   "usually because CIRCUITPY is mounted on a " +
-                   "computer over USB. Disconnect the USB cable, " +
-                   "or disable USB Mass Storage in boot.py, then " +
-                   "reset the board and try saving again. " +
-                   "(Ejecting the drive in your OS may not be " +
-                   "enough on its own.)";
+        // The board's filesystem is read-only to web workflow whenever
+        // USB Mass Storage support is enabled on the board, regardless
+        // of whether a host computer is actively using the drive. The
+        // common-case fix is to disable USB MSC in boot.py (which also
+        // hides the drive from the host); users who want both modes
+        // typically gate the disable on a button or pin check.
+        err.hint = "The board's filesystem is in read-only mode for " +
+                   "web workflow. This happens whenever USB Mass " +
+                   "Storage is enabled on the board (the default for " +
+                   "most CircuitPython boards), whether or not a host " +
+                   "computer has CIRCUITPY mounted. Disable USB Mass " +
+                   "Storage in boot.py and reset the board, or eject " +
+                   "CIRCUITPY and disconnect the USB data connection, " +
+                   "then try saving again.";
         err.helpUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
         err.helpLabel = "Disabling USB Mass Storage (Adafruit Learn)";
         return err;

--- a/js/script.js
+++ b/js/script.js
@@ -333,10 +333,14 @@ async function checkReadOnly() {
     } else if (readOnly) {
         // Concise connect-time notice that the filesystem is read-only,
         // with a link to the Learn guide for users who want the fix now.
+        // The cause is the board's USB Mass Storage support being
+        // enabled (the default on most boards) — saving from web
+        // workflow stays blocked whether or not a host actively has
+        // CIRCUITPY mounted.
         const learnUrl = "https://learn.adafruit.com/getting-started-with-web-workflow-using-the-code-editor/device-setup#disabling-usb-mass-storage-3125964";
         await showMessage(
             "Filesystem is read-only — you can browse files, but saving " +
-            "will fail until USB Mass Storage is released. " +
+            "will fail while USB Mass Storage is enabled on the board. " +
             `<a href="${learnUrl}" target="_blank" rel="noopener noreferrer">How to fix</a>.`
         );
     }
@@ -617,16 +621,27 @@ async function saveFileContents(path) {
                     // (sections, list, link) is fine. Sections separate the
                     // 'what happened', 'why', and 'how to fix' so users can
                     // scan instead of parsing a wall of prose.
+                    //
+                    // We intentionally don't assert that a host has
+                    // CIRCUITPY mounted: the board's filesystem becomes
+                    // read-only to web workflow whenever USB Mass
+                    // Storage is enabled on the board (the default for
+                    // most CircuitPython boards), even on a power-only
+                    // USB connection or a wall adapter. See #460 for
+                    // the full discussion.
                     await showMessage(
                         `<p><strong>Could not save '${workflow.currentFilename}'.</strong></p>` +
-                        `<p>The board's filesystem is locked, usually because ` +
-                        `CIRCUITPY is mounted on a computer over USB.</p>` +
+                        `<p>The board's filesystem is in read-only mode for web workflow. ` +
+                        `This happens whenever USB Mass Storage is enabled on the board ` +
+                        `(the default for most CircuitPython boards), whether or not a ` +
+                        `host computer is actively using it.</p>` +
                         `<p><strong>To fix:</strong></p>` +
                         `<ul style="margin: 0.25em 0 0.5em 1.25em; padding: 0;">` +
-                            `<li>Disconnect the USB cable, <em>or</em></li>` +
-                            `<li>Disable USB Mass Storage in <code>boot.py</code>, then reset the board.</li>` +
+                            `<li>Disable USB Mass Storage in <code>boot.py</code>, then reset the board, <em>or</em></li>` +
+                            `<li>If a computer has CIRCUITPY mounted, eject the drive and disconnect the USB data connection.</li>` +
                         `</ul>` +
-                        `<p><em>Note:</em> ejecting the drive in your OS isn't always enough on its own.</p>` +
+                        `<p><em>Heads up:</em> disabling USB Mass Storage in <code>boot.py</code> means the CIRCUITPY drive won't appear on a host computer either — you'll edit through web workflow only. Many makers use a button or pin check in <code>boot.py</code> to choose between the two modes at startup.</p>` +
+                        `<p><em>Note:</em> on macOS, ejecting the drive in Finder doesn't always release the board-side lock on its own.</p>` +
                         `<p><a href="${learnUrl}" target="_blank" rel="noopener noreferrer">${learnLabel}</a></p>` +
                         `<p>Your edits are still here — save again once the filesystem is writable.</p>`
                     );


### PR DESCRIPTION
## Summary

Refs #460 — the read-only filesystem dialog from PR #498 misdiagnoses
a real-world case the original reporter flagged: a board connected
to a USB **power-only** source (no host has CIRCUITPY mounted)
still hits the dialog and is told to disconnect a host that isn't
there.

This PR is a **messaging fix only** — the detection logic is
unchanged. It does **not** close #460; the underlying
"board-side filesystem stays locked while USB MSC is enabled even
when no host is using it" behavior is a firmware-side concern that
will be tracked separately.

## What changed

### `js/script.js`

Connect-time read-only notice:

> ~~Filesystem is read-only — you can browse files, but saving will fail until USB Mass Storage is **released**.~~ [How to fix].
>
> **Filesystem is read-only — you can browse files, but saving will fail while USB Mass Storage is *enabled* on the board.** [How to fix].

Save-failure dialog:

> ~~The board's filesystem is locked, usually because CIRCUITPY is mounted on a computer over USB.~~
>
> **The board's filesystem is in read-only mode for web workflow. This happens whenever USB Mass Storage is enabled on the board (the default for most CircuitPython boards), whether or not a host computer is actively using it.**

Reordered the fix list (boot.py disable comes first now, because
the alternate "just unplug USB" remedy only helps the smaller
subset of users where a host actually has it mounted), and added
a heads-up paragraph:

> **Heads up:** disabling USB Mass Storage in `boot.py` means the
> CIRCUITPY drive won't appear on a host computer either — you'll
> edit through web workflow only. Many makers use a button or pin
> check in `boot.py` to choose between the two modes at startup.

That note is the missing piece for the dual-workflow case the
original reporter (#460) called out: they work on the same project
both at the bench (Mu over USB) and deployed (web workflow), and
the previous dialog's only fix recommendation forced them to pick one.

### `js/common/web-file-transfer.js`

The `_writeProtectedError().hint` string (used as the fallback
when the editor doesn't render the dialog itself) is updated to
match the new framing — points at USB MSC being enabled, doesn't
assert host involvement.

## Why not just close #460 with this?

The dialog is now accurate, but the **underlying board behavior**
(filesystem stays write-protected while USB MSC is enabled, even
on power-only connections) is still surprising and arguably wrong
on hardware that never sees a real host. Investigating whether
the CircuitPython firmware should release the lock when no host
has done a real `WRITE10` in some window, or expose a cooperative
"yield to web workflow" mechanism, is its own piece of work and
belongs in [adafruit/circuitpython](https://github.com/adafruit/circuitpython).
That follow-up will be tracked separately; #460 stays open as
the umbrella.

## Testing

- `node --check` on both edited files passes.
- `npm run build` (vite) passes clean.
- Diff is messaging-only; no control-flow changes, no new
  branches, no API surface change.

## Refs

- Refs #460
- Builds on #498 (which added the writeProtected detection in
  the first place — that logic is preserved verbatim).
