### PR TITLE
Fix duplicate BLE connect/disconnect messages and 3rd-reconnect failure

### DIFF
--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -49,6 +49,19 @@ class BLEWorkflow extends Workflow {
         this._lastMutatingOpAt = 0;
         this._silentReconnectInFlight = false;
         this._silentReconnectPromise = null;
+
+        // Cached bound handlers so add/remove use the same reference.
+        // Without this, .bind() returns a fresh function every call and
+        // removeEventListener becomes a no-op, leaking listeners on every
+        // connect/reconnect cycle. See #410.
+        this._onRequestBluetoothDeviceClick = this.onRequestBluetoothDeviceButtonClick.bind(this);
+        this._onReconnectClick = this.reconnectButtonHandler.bind(this);
+        this._onSerialReceiveBound = this.onSerialReceive.bind(this);
+        this._onDisconnectedBound = this.onDisconnected.bind(this);
+
+        // Track in-flight watchAdvertisements abort controllers so we can
+        // cancel them when any device wins or when we tear down (#410).
+        this._pendingAdvAborts = new Set();
     }
 
     // Called by the FileTransferClient wrapper right before any mutating
@@ -93,12 +106,36 @@ class BLEWorkflow extends Workflow {
     async disconnectButtonHandler(e) {
         await super.disconnectButtonHandler(e);
         if (this.connectionStatus()) {
-            // Disconnect BlueTooth and Reset things
             if (this.bleDevice !== undefined && this.bleDevice.gatt.connected) {
+                // gatt.disconnect() fires gattserverdisconnected which calls
+                // onDisconnected via our listener — don't call onDisconnected
+                // again here or we double-log and double-fire UI updates.
+                // See #410.
                 this.bleDevice.gatt.disconnect();
+            } else {
+                // Already torn down at the GATT layer; run our cleanup directly.
+                await this.onDisconnected(e, false);
             }
-            await this.onDisconnected(e, false);
         }
+    }
+
+    async onDisconnected(e, reconnect = true) {
+        // Detach the gattserverdisconnected listener so a stale device handle
+        // can't fire onDisconnected later (the cause of the duplicate log
+        // accumulation in #410).
+        if (this.bleDevice) {
+            this.bleDevice.removeEventListener('gattserverdisconnected', this._onDisconnectedBound);
+        }
+        if (this.txCharacteristic) {
+            this.txCharacteristic.removeEventListener('characteristicvaluechanged', this._onSerialReceiveBound);
+        }
+        // Cancel any in-flight watchAdvertisements so a subsequent reconnect
+        // doesn't pile up Chrome's per-device watch quota (#410).
+        for (const ctrl of this._pendingAdvAborts) {
+            ctrl.abort();
+        }
+        this._pendingAdvAborts.clear();
+        await super.onDisconnected(e, reconnect);
     }
 
     async showConnect(documentState) {
@@ -114,8 +151,10 @@ class BLEWorkflow extends Workflow {
             request: btnRequestBluetoothDevice
         };
 
-        btnRequestBluetoothDevice.addEventListener('click', this.onRequestBluetoothDeviceButtonClick.bind(this));
-        btnReconnect.addEventListener('click', this.reconnectButtonHandler.bind(this));
+        btnRequestBluetoothDevice.removeEventListener('click', this._onRequestBluetoothDeviceClick);
+        btnRequestBluetoothDevice.addEventListener('click', this._onRequestBluetoothDeviceClick);
+        btnReconnect.removeEventListener('click', this._onReconnectClick);
+        btnReconnect.addEventListener('click', this._onReconnectClick);
 
         // Check if Web Bluetooth is available
         if (!(await this.available() instanceof Error)) {
@@ -155,9 +194,9 @@ class BLEWorkflow extends Workflow {
             this.txCharacteristic = await this.serialService.getCharacteristic(bleNusCharTXUUID);
             this.rxCharacteristic = await this.serialService.getCharacteristic(bleNusCharRXUUID);
 
-            // Remove any existing event listeners to prevent multiple reads
-            this.txCharacteristic.removeEventListener('characteristicvaluechanged', this.onSerialReceive.bind(this));
-            this.txCharacteristic.addEventListener('characteristicvaluechanged', this.onSerialReceive.bind(this));
+            // Use cached bound handler so removeEventListener actually matches.
+            this.txCharacteristic.removeEventListener('characteristicvaluechanged', this._onSerialReceiveBound);
+            this.txCharacteristic.addEventListener('characteristicvaluechanged', this._onSerialReceiveBound);
             await this.txCharacteristic.startNotifications();
             return true;
         } catch (e) {
@@ -197,11 +236,25 @@ class BLEWorkflow extends Workflow {
 
     async connectToBluetoothDevice(device) {
         const abortController = new AbortController();
+        this._pendingAdvAborts.add(abortController);
+        let advHandled = false;
 
         async function onAdvertisementReceived(event) {
+            // Multiple ads can land in the same event-loop tick before
+            // abortController.abort() takes effect on the listener. Guard
+            // so we only run the connect flow once per device. See #410.
+            if (advHandled) {
+                return;
+            }
+            advHandled = true;
             console.log('> Received advertisement from "' + device.name + '"...');
-            // Stop watching advertisements to conserve battery life.
-            abortController.abort();
+            // This device won. Abort ALL pending watchAdvertisements
+            // (including this one) so other paired devices stop scanning
+            // and don't pile up Chrome's per-device watch quota.
+            for (const ctrl of this._pendingAdvAborts) {
+                ctrl.abort();
+            }
+            this._pendingAdvAborts.clear();
             console.log('Connecting to GATT Server from "' + device.name + '"...');
             try {
                 this.bleServer = await device.gatt.connect();
@@ -220,8 +273,12 @@ class BLEWorkflow extends Workflow {
             }
         }
 
-        device.removeEventListener('advertisementreceived', onAdvertisementReceived.bind(this));
-        device.addEventListener('advertisementreceived', onAdvertisementReceived.bind(this));
+        // Use the abortController signal so we don't need to manage the
+        // handler reference manually — the listener is auto-removed when
+        // onAdvertisementReceived calls abortController.abort().
+        device.addEventListener('advertisementreceived',
+            onAdvertisementReceived.bind(this),
+            {signal: abortController.signal});
 
         this.debugLog("Attempting to connect to " + device.name + "...");
         try {
@@ -253,8 +310,8 @@ class BLEWorkflow extends Workflow {
 
     async switchToDevice(device) {
         this.bleDevice = device;
-        this.bleDevice.removeEventListener("gattserverdisconnected", this.onDisconnected.bind(this));
-        this.bleDevice.addEventListener("gattserverdisconnected", this.onDisconnected.bind(this));
+        this.bleDevice.removeEventListener("gattserverdisconnected", this._onDisconnectedBound);
+        this.bleDevice.addEventListener("gattserverdisconnected", this._onDisconnectedBound);
         console.log("connected", this.bleServer);
 
         try {
@@ -368,9 +425,9 @@ class BLEWorkflow extends Workflow {
 
     // Rebind characteristics after silent reconnect without rebuilding fileHelper.
     async _rebindAfterSilentReconnect() {
-        // Re-attach disconnect listener (idempotent).
-        this.bleDevice.removeEventListener('gattserverdisconnected', this.onDisconnected.bind(this));
-        this.bleDevice.addEventListener('gattserverdisconnected', this.onDisconnected.bind(this));
+        // Re-attach disconnect listener (idempotent thanks to cached bound ref).
+        this.bleDevice.removeEventListener('gattserverdisconnected', this._onDisconnectedBound);
+        this.bleDevice.addEventListener('gattserverdisconnected', this._onDisconnectedBound);
 
         // NUS serial chars need re-fetch; BLE-FT chars re-fetched lazily by checkConnection().
         await this.connectToSerial();


### PR DESCRIPTION
Closes #410.

## Symptoms

In the BLE workflow, repeated connect/disconnect cycles would:

- Log multiple `Connected to ...` and `disconnected` lines per single user action (1 → 2 → 3 → ... per cycle).
- After ~3 reconnect cycles, the **Reconnect** button would log `Attempting to connect to ...` for each paired device but never actually establish a connection, with no error.

Reproduces on Feather S3 Reverse TFT (reporter's hardware) and CLUE nRF52840 (my test rig) running CircuitPython 10.x. Chrome latest.

## Root causes

Five overlapping bugs in `js/workflows/ble.js`:

### 1. `.bind(this)` returning a fresh function each call

```js
this.bleDevice.removeEventListener("gattserverdisconnected", this.onDisconnected.bind(this));
this.bleDevice.addEventListener("gattserverdisconnected", this.onDisconnected.bind(this));
```

`removeEventListener` only matches by reference, so the remove was a no-op. Every `switchToDevice` / `_rebindAfterSilentReconnect` / `_loadDom` call added another listener on top of the old ones.

**Fix:** Cache each bound handler on the instance in the constructor and reuse the same reference for add/remove. Pattern already used in `usb.js`.

### 2. `disconnectButtonHandler` double-firing `onDisconnected`

```js
this.bleDevice.gatt.disconnect();   // fires gattserverdisconnected -> onDisconnected
await this.onDisconnected(e, false); // ALSO calls onDisconnected manually
```

Two trips through `onDisconnected` per disconnect click → two log lines, two UI updates, two `connect()` recursions.

**Fix:** Only call `onDisconnected` manually when the GATT layer was already torn down (`!gatt.connected`); otherwise let the GATT event drive cleanup.

### 3. `onAdvertisementReceived` not guarded against re-entry

BLE peripherals can deliver several ads in the same event-loop tick before `abortController.abort()` actually detaches the listener. The handler would run multiple times per device, calling `switchToDevice` and `onConnected` multiple times.

**Fix:** Closure-local `advHandled` boolean; bail on subsequent entries.

### 4. Stale `watchAdvertisements` exhausting Chrome's per-device quota

`reconnectButtonHandler` iterates ALL paired devices and starts `watchAdvertisements` on each. Only one device responds; the others keep watching indefinitely. After several reconnect cycles, each device has multiple background watches, and Chrome silently stops delivering `advertisementreceived` events.

This is why the 3rd reconnect failed: the watches were active per Chrome's bookkeeping, but no events were being routed to our handlers.

**Fix:** Track every in-flight `AbortController` in `this._pendingAdvAborts` (Set). When any device wins, abort all of them (winner + losers). Also clear the Set on disconnect.

### 5. BLE-specific `onDisconnected` to detach lingering listeners

Even with fix #1, the device handle itself persists across reconnect cycles, and stale `gattserverdisconnected` listeners attached to old transitions could fire spuriously.

**Fix:** Add a BLE-specific `onDisconnected` override that detaches `gattserverdisconnected` from `bleDevice` and `characteristicvaluechanged` from `txCharacteristic` before delegating to `super.onDisconnected`.

## Test protocol

On a CLUE running CircuitPython 10.0.0, with 3 paired BLE devices visible to Chrome:

Before:
```
Attempting to connect to CIRCUITPY732a...
Connected to CIRCUITPY732a
disconnected
disconnected
Attempting to connect to CIRCUITPY732a...
Attempting to connect to CIRCUITPY732a...
Connected to CIRCUITPY732a
Connected to CIRCUITPY732a
disconnected
disconnected
disconnected
disconnected
... (3rd reconnect attempt logs "Attempting..." x3 but never connects)
```

After (verified by @makermelissa on Feather S3 Reverse TFT, 4+ cycles):
```
Attempting to connect to CIRCUITPY732a...
Attempting to connect to CIRCUITPY88bc...
Attempting to connect to CIRCUITPY4841...
Connected to CIRCUITPY732a
disconnected
Attempting to connect to CIRCUITPY732a...
Attempting to connect to CIRCUITPY88bc...
Attempting to connect to CIRCUITPY4841...
Connected to CIRCUITPY732a
disconnected
... (reliably reconnects every cycle, single log line per event)
```

(The N "Attempting" lines per cycle are expected: `reconnectButtonHandler` checks every paired device because we can't know in advance which one is on. Only the responsive one produces a `Connected`.)

## Out of scope

- The "fall-through to `connect()` after disconnect is a no-op when `bleDevice` is still set" path. The `reconnectButtonHandler` flow works because it doesn't depend on that path. A future PR could refactor to clear `bleDevice` on disconnect so auto-reconnect via `connect()` also works, but that interacts with the silent-reconnect path from #511 and deserves its own change.
- BLE-FT upstream library's unconditional `this._resolve(...)` calls during reconnect (separate issue noted in #511 work).

cc @makermelissa
