### PR TITLE
Fallback for serial USB drive helpers

### DIFF
--- a/js/workflows/usb.js
+++ b/js/workflows/usb.js
@@ -330,7 +330,25 @@ class USBWorkflow extends Workflow {
 
     async _trySerialFileTransfer() {
         try {
-            if (await this.showBusy(this.repl.tryDisableUsbDrive())) {
+            let usbDriveDisabled;
+            if (typeof this.repl.tryDisableUsbDrive === "function") {
+                usbDriveDisabled = await this.showBusy(this.repl.tryDisableUsbDrive());
+            } else {
+                const disabledMarker = "WEB_EDITOR_USB_DRIVE_DISABLED";
+                const code = `
+try:
+    import storage
+    if hasattr(storage, "unsafe_disable_usb_drive"):
+        storage.unsafe_disable_usb_drive()
+        print("${disabledMarker}")
+except Exception:
+    pass
+`;
+                const result = await this.showBusy(this.repl.runCode(code));
+                usbDriveDisabled = String(result || "").includes(disabledMarker);
+            }
+
+            if (usbDriveDisabled) {
                 this._usbDriveDisabled = true;
                 console.log("CIRCUITPY USB drive disabled; using serial file transfer");
                 return true;
@@ -347,7 +365,18 @@ class USBWorkflow extends Workflow {
         }
 
         try {
-            if (await this.repl.enableUsbDrive()) {
+            let usbDriveRestored;
+            if (typeof this.repl.enableUsbDrive === "function") {
+                usbDriveRestored = await this.repl.enableUsbDrive();
+            } else {
+                await this.repl.runCode(
+`import storage
+storage.enable_usb_drive()`
+                );
+                usbDriveRestored = true;
+            }
+
+            if (usbDriveRestored) {
                 console.log("CIRCUITPY USB drive restored");
             } else {
                 console.warn("CircuitPython could not restore the CIRCUITPY USB drive");


### PR DESCRIPTION
## Summary
- fall back to inline CircuitPython snippets when `circuitpython-repl-js` does not expose `tryDisableUsbDrive()` / `enableUsbDrive()`
- preserves serial file transfer for supported beta firmware such as 10.3.0-alpha builds even when the bundled REPL helper API is unavailable

## Testing
- `npm run build`
- `git diff --check`

## Notes
Console error observed before this fix:

```text
Unable to disable the CIRCUITPY USB drive: TypeError: this.repl.tryDisableUsbDrive is not a function
```
