### PR TITLE
Bound the BLE connect and file-read waits so they report instead of hanging

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@
                 </tr>
             </tbody>
         </table>
+        <div id="message"></div>
         <div id="firmware-update" class="firmware-update-suggestion-container"></div>
         <h3>More network devices<i class="refresh fa-solid fa-sync-alt" title="Refresh Device List"></i></h3>
         <div id="devices"></div>
@@ -435,6 +436,7 @@
                 </tr>
             </tbody>
         </table>
+        <div id="message"></div>
         <div id="firmware-update" class="firmware-update-suggestion-container"></div>
         <div class="buttons centered">
             <button class="purple-button ok-button">Close</button>

--- a/js/common/ble-file-transfer.js
+++ b/js/common/ble-file-transfer.js
@@ -8,52 +8,6 @@ class FileTransferClient extends BLEFileTransferClient {
     constructor(bleDevice, bufferSize, workflow = null) {
         super(bleDevice, bufferSize);
         this._workflow = workflow;
-        this._bleDevice = bleDevice;
-    }
-
-    // Reject a read if the GATT link is already down, or drops while it is in
-    // flight, instead of returning a promise that can never settle.
-    //
-    // Upstream readFile()/listDir() install their promise's reject handler
-    // AFTER writing the request:
-    //
-    //     await this._write(header);
-    //     await this._write(encoded);
-    //     let p = new Promise((resolve, reject) => {
-    //         this._resolve = resolve;
-    //         this._reject = reject;      // too late
-    //     });
-    //
-    // On a dead link `_transfer` is null, so both writes throw; _write()
-    // swallows the error and calls onDisconnected(), which has no `_reject` to
-    // call yet. checkConnection() likewise catches its own failure and returns
-    // normally rather than rethrowing, so the read proceeds regardless. The
-    // returned promise is then never settled by anyone and the caller hangs --
-    // which is what left the editor spinning on "Current Device Info".
-    //
-    // Bound on liveness rather than elapsed time: a large file read over BLE can
-    // legitimately take tens of seconds, so a stopwatch would produce false
-    // failures, while a dropped link is unambiguous.
-    _whileConnected(operation) {
-        const device = this._bleDevice;
-        if (!device || !device.gatt || !device.gatt.connected) {
-            return Promise.reject(new Error("Bluetooth device is not connected"));
-        }
-        return new Promise((resolve, reject) => {
-            const onDisconnected = () => reject(new Error("Bluetooth device disconnected"));
-            device.addEventListener("gattserverdisconnected", onDisconnected, {once: true});
-            operation().then(resolve, reject).finally(() => {
-                device.removeEventListener("gattserverdisconnected", onDisconnected);
-            });
-        });
-    }
-
-    async readFile(path, raw = false) {
-        return await this._whileConnected(() => super.readFile(path, raw));
-    }
-
-    async listDir(path) {
-        return await this._whileConnected(() => super.listDir(path));
     }
 
     _signalMutatingOp() {

--- a/js/common/ble-file-transfer.js
+++ b/js/common/ble-file-transfer.js
@@ -8,6 +8,52 @@ class FileTransferClient extends BLEFileTransferClient {
     constructor(bleDevice, bufferSize, workflow = null) {
         super(bleDevice, bufferSize);
         this._workflow = workflow;
+        this._bleDevice = bleDevice;
+    }
+
+    // Reject a read if the GATT link is already down, or drops while it is in
+    // flight, instead of returning a promise that can never settle.
+    //
+    // Upstream readFile()/listDir() install their promise's reject handler
+    // AFTER writing the request:
+    //
+    //     await this._write(header);
+    //     await this._write(encoded);
+    //     let p = new Promise((resolve, reject) => {
+    //         this._resolve = resolve;
+    //         this._reject = reject;      // too late
+    //     });
+    //
+    // On a dead link `_transfer` is null, so both writes throw; _write()
+    // swallows the error and calls onDisconnected(), which has no `_reject` to
+    // call yet. checkConnection() likewise catches its own failure and returns
+    // normally rather than rethrowing, so the read proceeds regardless. The
+    // returned promise is then never settled by anyone and the caller hangs --
+    // which is what left the editor spinning on "Current Device Info".
+    //
+    // Bound on liveness rather than elapsed time: a large file read over BLE can
+    // legitimately take tens of seconds, so a stopwatch would produce false
+    // failures, while a dropped link is unambiguous.
+    _whileConnected(operation) {
+        const device = this._bleDevice;
+        if (!device || !device.gatt || !device.gatt.connected) {
+            return Promise.reject(new Error("Bluetooth device is not connected"));
+        }
+        return new Promise((resolve, reject) => {
+            const onDisconnected = () => reject(new Error("Bluetooth device disconnected"));
+            device.addEventListener("gattserverdisconnected", onDisconnected, {once: true});
+            operation().then(resolve, reject).finally(() => {
+                device.removeEventListener("gattserverdisconnected", onDisconnected);
+            });
+        });
+    }
+
+    async readFile(path, raw = false) {
+        return await this._whileConnected(() => super.readFile(path, raw));
+    }
+
+    async listDir(path) {
+        return await this._whileConnected(() => super.listDir(path));
     }
 
     _signalMutatingOp() {

--- a/js/common/dialogs.js
+++ b/js/common/dialogs.js
@@ -340,9 +340,28 @@ class ButtonValueDialog extends GenericModal {
     }
 }
 
+// Report a failed device-info read in the dialog. Without this the read's
+// rejection escapes as an unhandled promise rejection and the dialog is simply
+// left blank, which reads as "the device answered with nothing" rather than
+// "we never reached the device".
+function showDeviceInfoError(modal, error) {
+    console.error("Unable to read device info:", error);
+    const msgElement = modal.querySelector("#message");
+    if (msgElement) {
+        msgElement.textContent =
+            "Could not read device information. The connection to the device was lost.";
+    }
+}
+
 class DiscoveryModal extends GenericModal {
     async _getVersionInfo() {
-        const deviceInfo = await this._showBusy(this._fileHelper.versionInfo());
+        let deviceInfo;
+        try {
+            deviceInfo = await this._showBusy(this._fileHelper.versionInfo());
+        } catch (error) {
+            showDeviceInfoError(this._currentModal, error);
+            return;
+        }
         this._currentModal.querySelector("#version").textContent = deviceInfo.version;
         const boardLink = this._currentModal.querySelector("#board");
         boardLink.href = `https://circuitpython.org/board/${deviceInfo.board_id}/`;
@@ -413,7 +432,13 @@ class DiscoveryModal extends GenericModal {
 
 class DeviceInfoModal extends GenericModal {
         async _getDeviceInfo() {
-        const deviceInfo = await this._showBusy(this._fileHelper.versionInfo());
+        let deviceInfo;
+        try {
+            deviceInfo = await this._showBusy(this._fileHelper.versionInfo());
+        } catch (error) {
+            showDeviceInfoError(this._currentModal, error);
+            return;
+        }
         this._currentModal.querySelector("#version").textContent = deviceInfo.version;
         const boardLink = this._currentModal.querySelector("#board");
         boardLink.href = `https://circuitpython.org/board/${deviceInfo.board_id}/`;

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -285,17 +285,21 @@ class BLEWorkflow extends Workflow {
             this._connectAttemptInFlight = true;
             clearTimeout(advTimer);
 
-            // This device won. Stop the OTHER devices' watches so they don't
-            // pile up Chrome's per-device watch quota. This device keeps its
-            // own watch until the connect settles: on Linux the kernel only
-            // takes the working connect path while a discovery session is
-            // active, and Chrome holds one for the lifetime of the watch.
-            this._abortAdvWatches(abortController);
+            // This device won. Stop every pending watch, this device's
+            // included, BEFORE connecting -- Chrome holds a BlueZ discovery
+            // session for as long as any watch is armed, and connecting while
+            // one is active is what fails on Linux. Measured by driving
+            // Device1.Connect() directly: discovery stopped 36/36, discovery
+            // active 18/52. Intermittent -- a host suspend/resume clears the
+            // failing state until the next boot, so it may not reproduce. In
+            // the failing case the HCI create-connection is identical to a
+            // working one and the controller simply transmits nothing until
+            // the attempt is cancelled ~20s later.
+            this._abortAdvWatches();
             try {
                 await this._connectToGattServer(device, reason);
             } finally {
                 this._connectAttemptInFlight = false;
-                this._abortAdvWatches();
             }
         };
 

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -40,6 +40,11 @@ const ADVERTISEMENT_WAIT_MS = 2000;
 // measured from 0.5s (macOS, Windows) up to 26.6s (Linux), hence the generous
 // ceiling.
 const CONNECT_TIMEOUT_MS = 30000;
+// Per-attempt bound for the silent reconnect after a firmware autoreload.
+// Shorter than CONNECT_TIMEOUT_MS because this path runs once per entry in
+// RECONNECT_DELAYS_MS, and a reconnect that has not landed within ten seconds
+// has stopped being silent regardless of whether it eventually succeeds.
+const SILENT_RECONNECT_TIMEOUT_MS = 10000;
 
 let btnRequestBluetoothDevice, btnReconnect;
 
@@ -326,23 +331,33 @@ class BLEWorkflow extends Workflow {
     // Connect with a bound. gatt.connect() does not always reject on its own --
     // on Linux with a watch armed it never settles -- so race it against a timer
     // and cancel with gatt.disconnect(), which is the only way page JS can abort
-    // an in-flight connect.
-    async _connectToGattServer(device, reason) {
-        console.log(`Connecting to GATT Server from "${device.name}" (${reason})...`);
-        this.showConnectStatus("Connecting to " + device.name + "...");
-
+    // an in-flight connect. Chrome has honoured disconnect() as a cancel since
+    // M140; before that the attempt is orphaned rather than aborted, so treat a
+    // timeout as fatal rather than assuming the adapter is left clean.
+    async _connectWithTimeout(device, timeoutMs) {
         let connectTimer;
         try {
-            this.bleServer = await Promise.race([
+            return await Promise.race([
                 device.gatt.connect(),
                 new Promise((_, reject) => {
                     connectTimer = setTimeout(() => {
                         device.gatt.disconnect();
                         reject(new Error(
-                            `connect did not complete within ${CONNECT_TIMEOUT_MS / 1000}s`));
-                    }, CONNECT_TIMEOUT_MS);
+                            `connect did not complete within ${timeoutMs / 1000}s`));
+                    }, timeoutMs);
                 }),
             ]);
+        } finally {
+            clearTimeout(connectTimer);
+        }
+    }
+
+    async _connectToGattServer(device, reason) {
+        console.log(`Connecting to GATT Server from "${device.name}" (${reason})...`);
+        this.showConnectStatus("Connecting to " + device.name + "...");
+
+        try {
+            this.bleServer = await this._connectWithTimeout(device, CONNECT_TIMEOUT_MS);
         } catch (error) {
             console.log(error);
             // TODO(ericzundel): Add to suggestBLEConnectAction if we can determine the exception type
@@ -352,9 +367,6 @@ class BLEWorkflow extends Workflow {
             // Disable the reconnect button
             this.connectionStep(1);
             return;
-        }
-        finally {
-            clearTimeout(connectTimer);
         }
 
         if (this.bleServer && this.bleServer.connected) {
@@ -479,7 +491,11 @@ class BLEWorkflow extends Workflow {
                 await sleep(delay);
                 try {
                     console.log(`Silent reconnect: attempting after ${delay}ms…`);
-                    this.bleServer = await this.bleDevice.gatt.connect();
+                    // Bounded: an unbounded connect here stalls the whole
+                    // reconnect ladder, and every mutating op waits on it via
+                    // awaitPostOpReconnect(), so a save appears to hang.
+                    this.bleServer = await this._connectWithTimeout(
+                        this.bleDevice, SILENT_RECONNECT_TIMEOUT_MS);
                     if (this.bleServer && this.bleServer.connected) {
                         console.log('Silent reconnect: GATT reconnected, rebinding characteristics…');
                         await this._rebindAfterSilentReconnect();

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -25,6 +25,19 @@ const POST_OP_DISCONNECT_GRACE_MS = 4000;
 // Wait after GATT reconnects so the VM finishes booting before the next op.
 const POST_RECONNECT_SETTLE_MS = 2000;
 
+// How long to wait for an advertisement before connecting anyway. Chrome's
+// BlueZ backend never delivers advertisementreceived, so on Linux this event
+// does not arrive at all and an unbounded wait leaves the connect dialog open
+// forever with no feedback. macOS delivers the first event within ~30ms, so a
+// few seconds is generous everywhere it works.
+const ADVERTISEMENT_WAIT_MS = 5000;
+// How long to allow gatt.connect() before giving up. Chrome bounds this itself
+// at ~41s on Linux, but not while a watchAdvertisements() watch is armed -- in
+// that state the promise simply never settles. Successful connects have been
+// measured from 0.5s (macOS, Windows) up to 26.6s (Linux), hence the generous
+// ceiling.
+const CONNECT_TIMEOUT_MS = 30000;
+
 let btnRequestBluetoothDevice, btnReconnect;
 
 class BLEWorkflow extends Workflow {
@@ -62,6 +75,11 @@ class BLEWorkflow extends Workflow {
         // Track in-flight watchAdvertisements abort controllers so we can
         // cancel them when any device wins or when we tear down (#410).
         this._pendingAdvAborts = new Set();
+
+        // Only one device may attempt a connection at a time. Without this,
+        // several remembered devices whose advertisement waits expire together
+        // would all try to connect at once.
+        this._connectAttemptInFlight = false;
     }
 
     // Called by the FileTransferClient wrapper right before any mutating
@@ -131,10 +149,7 @@ class BLEWorkflow extends Workflow {
         }
         // Cancel any in-flight watchAdvertisements so a subsequent reconnect
         // doesn't pile up Chrome's per-device watch quota (#410).
-        for (const ctrl of this._pendingAdvAborts) {
-            ctrl.abort();
-        }
-        this._pendingAdvAborts.clear();
+        this._abortAdvWatches();
         await super.onDisconnected(e, reconnect);
     }
 
@@ -234,51 +249,59 @@ class BLEWorkflow extends Workflow {
         });
     }
 
+    // Abort pending advertisement watches, optionally sparing one. Deleting
+    // while iterating a Set is safe.
+    _abortAdvWatches(keep = null) {
+        for (const ctrl of this._pendingAdvAborts) {
+            if (ctrl !== keep) {
+                ctrl.abort();
+                this._pendingAdvAborts.delete(ctrl);
+            }
+        }
+    }
+
     async connectToBluetoothDevice(device) {
         const abortController = new AbortController();
         this._pendingAdvAborts.add(abortController);
         let advHandled = false;
 
-        async function onAdvertisementReceived(event) {
-            // Multiple ads can land in the same event-loop tick before
-            // abortController.abort() takes effect on the listener. Guard
-            // so we only run the connect flow once per device. See #410.
-            if (advHandled) {
+        // Runs either when an advertisement arrives or when we give up waiting
+        // for one. Guarded because multiple ads can land in the same event-loop
+        // tick before abortController.abort() takes effect on the listener, and
+        // because the timer can fire alongside a late advertisement. See #410.
+        const attemptConnect = async (reason) => {
+            if (advHandled || this._connectAttemptInFlight) {
                 return;
             }
             advHandled = true;
-            console.log('> Received advertisement from "' + device.name + '"...');
-            // This device won. Abort ALL pending watchAdvertisements
-            // (including this one) so other paired devices stop scanning
-            // and don't pile up Chrome's per-device watch quota.
-            for (const ctrl of this._pendingAdvAborts) {
-                ctrl.abort();
-            }
-            this._pendingAdvAborts.clear();
-            console.log('Connecting to GATT Server from "' + device.name + '"...');
+            this._connectAttemptInFlight = true;
+            clearTimeout(advTimer);
+
+            // This device won. Stop the OTHER devices' watches so they don't
+            // pile up Chrome's per-device watch quota. This device keeps its
+            // own watch until the connect settles: on Linux the kernel only
+            // takes the working connect path while a discovery session is
+            // active, and Chrome holds one for the lifetime of the watch.
+            this._abortAdvWatches(abortController);
             try {
-                this.bleServer = await device.gatt.connect();
-            } catch (error) {
-                console.log(error);
-                // TODO(ericzundel): Add to suggestBLEConnectAction if we can determine the exception type
-                this.showConnectStatus("Failed to connect to device. Try forgetting device from OS bluetooth devices and try again.");
-                // Disable the reconnect button
-                this.connectionStep(1);
+                await this._connectToGattServer(device, reason);
+            } finally {
+                this._connectAttemptInFlight = false;
+                this._abortAdvWatches();
             }
-            if (this.bleServer && this.bleServer.connected) {
-                console.log('> Bluetooth device "' +  device.name + ' connected.');
-                await this.switchToDevice(device);
-            } else {
-                console.log('Unable to connect to bluetooth device "' +  device.name + '.');
-            }
-        }
+        };
+
+        const advTimer = setTimeout(
+            () => attemptConnect(`no advertisement within ${ADVERTISEMENT_WAIT_MS / 1000}s`),
+            ADVERTISEMENT_WAIT_MS);
 
         // Use the abortController signal so we don't need to manage the
         // handler reference manually — the listener is auto-removed when
-        // onAdvertisementReceived calls abortController.abort().
-        device.addEventListener('advertisementreceived',
-            onAdvertisementReceived.bind(this),
-            {signal: abortController.signal});
+        // abortController.abort() is called.
+        device.addEventListener('advertisementreceived', () => {
+            console.log('> Received advertisement from "' + device.name + '"...');
+            attemptConnect('advertisement received');
+        }, {signal: abortController.signal});
 
         this.debugLog("Attempting to connect to " + device.name + "...");
         try {
@@ -288,8 +311,53 @@ class BLEWorkflow extends Workflow {
             await device.watchAdvertisements({signal: abortController.signal});
         }
         catch (error) {
+            clearTimeout(advTimer);
             console.error(error);
             this.showConnectStatus(this._suggestBLEConnectActions(error));
+        }
+    }
+
+    // Connect with a bound. gatt.connect() does not always reject on its own --
+    // on Linux with a watch armed it never settles -- so race it against a timer
+    // and cancel with gatt.disconnect(), which is the only way page JS can abort
+    // an in-flight connect.
+    async _connectToGattServer(device, reason) {
+        console.log(`Connecting to GATT Server from "${device.name}" (${reason})...`);
+        this.showConnectStatus("Connecting to " + device.name + "...");
+
+        let connectTimer;
+        try {
+            this.bleServer = await Promise.race([
+                device.gatt.connect(),
+                new Promise((_, reject) => {
+                    connectTimer = setTimeout(() => {
+                        device.gatt.disconnect();
+                        reject(new Error(
+                            `connect did not complete within ${CONNECT_TIMEOUT_MS / 1000}s`));
+                    }, CONNECT_TIMEOUT_MS);
+                }),
+            ]);
+        } catch (error) {
+            console.log(error);
+            // TODO(ericzundel): Add to suggestBLEConnectAction if we can determine the exception type
+            this.showConnectStatus(
+                `Could not connect to ${device.name}. Try again. If it keeps failing, forget the ` +
+                `device in your operating system's Bluetooth settings, then reload this page.`);
+            // Disable the reconnect button
+            this.connectionStep(1);
+            return;
+        }
+        finally {
+            clearTimeout(connectTimer);
+        }
+
+        if (this.bleServer && this.bleServer.connected) {
+            console.log('> Bluetooth device "' + device.name + '" connected.');
+            await this.switchToDevice(device);
+        } else {
+            console.log('Unable to connect to bluetooth device "' + device.name + '".');
+            this.showConnectStatus(`Could not connect to ${device.name}. Try again.`);
+            this.connectionStep(1);
         }
     }
 

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -240,6 +240,7 @@ class BLEWorkflow extends Workflow {
                 const devices = await navigator.bluetooth.getDevices();
 
                 console.log('> Found ' + devices.length + ' Bluetooth device(s).');
+                this._showSearchingStatus(devices);
                 // These devices may not be powered on or in range, so scan for
                 // advertisement packets from them before connecting.
                 for (const device of devices) {
@@ -259,6 +260,20 @@ class BLEWorkflow extends Workflow {
             filters: [{services: [0xfebb]},], // <- Prefer filters to save energy & show relevant devices.
             optionalServices: [0xfebb, bleNusServiceUUID]
         });
+    }
+
+    // Say something during the advertisement wait. On Linux it always runs to the
+    // full timeout, and silence looks like a hang. Naming a device is only honest
+    // when there is one: the reconnect paths race every permitted device and
+    // connect to whichever answers first, which need not be the one named.
+    _showSearchingStatus(devices) {
+        if (devices.length === 0) {
+            return;
+        }
+        this.clearConnectStatus();
+        this.showConnectStatus(devices.length === 1
+            ? "Looking for " + devices[0].name + "..."
+            : "Looking for " + devices.length + " previously connected boards...");
     }
 
     // Abort pending advertisement watches, optionally sparing one. Deleting
@@ -332,10 +347,10 @@ class BLEWorkflow extends Workflow {
 
         this.debugLog("Attempting to connect to " + device.name + "...");
         try {
-            this.clearConnectStatus();
-            // Say something during the advertisement wait. On Linux it always
-            // runs to the full timeout, and silence looks like a hang.
-            this.showConnectStatus("Looking for " + device.name + "...");
+            // No status message here. The caller has already said what it is
+            // looking for, and naming this device would be wrong: the reconnect
+            // paths arm a watch on every permitted device at once, so each call
+            // would overwrite the last and leave a loser's name on screen.
             console.log('Watching advertisements from "' + device.name + '"...');
             console.log('If no advertisements are received, make sure the device is powered on and in range. You can also try resetting the device.');
             await device.watchAdvertisements({signal: abortController.signal});
@@ -405,6 +420,7 @@ class BLEWorkflow extends Workflow {
         let device = await this.requestDevice();
 
         console.log('> Requested ' + device.name);
+        this._showSearchingStatus([device]);
         await this.connectToBluetoothDevice(device);
     }
 
@@ -487,6 +503,7 @@ class BLEWorkflow extends Workflow {
         if (!this.bleDevice) {
             try {
                 let devices = await navigator.bluetooth.getDevices();
+                this._showSearchingStatus(devices);
                 for (const device of devices) {
                     await this.connectToBluetoothDevice(device);
                 }

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -224,6 +224,21 @@ class BLEWorkflow extends Workflow {
             // Use cached bound handler so removeEventListener actually matches.
             this.txCharacteristic.removeEventListener('characteristicvaluechanged', this._onSerialReceiveBound);
             this.txCharacteristic.addEventListener('characteristicvaluechanged', this._onSerialReceiveBound);
+
+            // Stop before starting, so a CCCD write actually goes out. Reconnecting to a
+            // bonded board, startNotifications() can return without writing the
+            // descriptor, leaving the board with notifications disabled -- the terminal
+            // then stays silent for the rest of the session while file transfer works.
+            // Measured on a Feather nRF52840 and a Metro ESP32-S3, on Linux and Windows.
+            //
+            // No read is needed first here, unlike the file transfer client's own
+            // subscribe: switchToDevice() bonds through the file transfer client before
+            // calling this, so the link is already encrypted by now.
+            try {
+                await this.txCharacteristic.stopNotifications();
+            } catch (e) {
+                // Nothing was subscribed yet, which is the ordinary first connect.
+            }
             await this.txCharacteristic.startNotifications();
             return true;
         } catch (e) {

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -36,9 +36,13 @@ const POST_RECONNECT_SETTLE_MS = 2000;
 const ADVERTISEMENT_WAIT_MS = 2000;
 // How long to allow gatt.connect() before giving up. Chrome bounds this itself
 // at ~41s on Linux, but not while a watchAdvertisements() watch is armed -- in
-// that state the promise simply never settles. Successful connects have been
-// measured from 0.5s (macOS, Windows) up to 26.6s (Linux), hence the generous
-// ceiling.
+// that state the promise simply never settles, which is the case this timeout
+// exists for. The ceiling is deliberately loose rather than tuned: a healthy
+// adapter connects in well under a second (0.5s on macOS and Windows, 0.7s
+// median on an Intel AX210 on Linux), but a user's host controller may be far
+// slower -- 26.6s was measured on a faulty MediaTek MT7920. The point is to
+// convert a never-settling promise into a reportable failure, not to enforce a
+// tight deadline.
 const CONNECT_TIMEOUT_MS = 30000;
 // Per-attempt bound for the silent reconnect after a firmware autoreload.
 // Shorter than CONNECT_TIMEOUT_MS because this path runs once per entry in
@@ -285,16 +289,27 @@ class BLEWorkflow extends Workflow {
             this._connectAttemptInFlight = true;
             clearTimeout(advTimer);
 
-            // This device won. Stop every pending watch, this device's
-            // included, BEFORE connecting -- Chrome holds a BlueZ discovery
-            // session for as long as any watch is armed, and connecting while
-            // one is active is what fails on Linux. Measured by driving
-            // Device1.Connect() directly: discovery stopped 36/36, discovery
-            // active 18/52. Intermittent -- a host suspend/resume clears the
-            // failing state until the next boot, so it may not reproduce. In
-            // the failing case the HCI create-connection is identical to a
-            // working one and the controller simply transmits nothing until
-            // the attempt is cancelled ~20s later.
+            // This device won, so stop every pending watch, this device's
+            // included. The reason is the one from #410: Chrome enforces a
+            // per-device watchAdvertisements quota, and leaving the losers
+            // armed piles up against it.
+            //
+            // An earlier version of this comment claimed the abort was needed
+            // because connecting while a BlueZ discovery session is active
+            // fails on Linux. That was investigated at length and does not
+            // hold: the connect failures it described were the host Bluetooth
+            // controller (a MediaTek MT7920, 0/40 while WiFi scanned), not the
+            // discovery state, and the same board connects 20/20 on an Intel
+            // AX210 with a watch armed or not. The kernel also disables
+            // scanning ~1.5ms before every create-connection regardless of
+            // what BlueZ believes, so aborting the watch does not change the
+            // controller's state at the moment of connect.
+            //
+            // Ordering it before the connect is therefore housekeeping, not a
+            // workaround, and on Linux it may even cost a little: Chrome's
+            // discovery session is what refreshes BlueZ's 30s sighting window,
+            // and gatt.connect() rejects with "no longer in range" once that
+            // window lapses.
             this._abortAdvWatches();
             try {
                 await this._connectToGattServer(device, reason);

--- a/js/workflows/ble.js
+++ b/js/workflows/ble.js
@@ -29,8 +29,11 @@ const POST_RECONNECT_SETTLE_MS = 2000;
 // BlueZ backend never delivers advertisementreceived, so on Linux this event
 // does not arrive at all and an unbounded wait leaves the connect dialog open
 // forever with no feedback. macOS delivers the first event within ~30ms, so a
-// few seconds is generous everywhere it works.
-const ADVERTISEMENT_WAIT_MS = 5000;
+// couple of seconds is generous everywhere it works. On Linux the wait is not
+// wasted even though nothing arrives: the discovery session that
+// watchAdvertisements() opens is what makes BlueZ (re)create its device object,
+// without which gatt.connect() rejects as "no longer in range".
+const ADVERTISEMENT_WAIT_MS = 2000;
 // How long to allow gatt.connect() before giving up. Chrome bounds this itself
 // at ~41s on Linux, but not while a watchAdvertisements() watch is armed -- in
 // that state the promise simply never settles. Successful connects have been
@@ -306,6 +309,9 @@ class BLEWorkflow extends Workflow {
         this.debugLog("Attempting to connect to " + device.name + "...");
         try {
             this.clearConnectStatus();
+            // Say something during the advertisement wait. On Linux it always
+            // runs to the full timeout, and silence looks like a hang.
+            this.showConnectStatus("Looking for " + device.name + "...");
             console.log('Watching advertisements from "' + device.name + '"...');
             console.log('If no advertisements are received, make sure the device is powered on and in range. You can also try resetting the device.');
             await device.watchAdvertisements({signal: abortController.signal});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-editor",
       "version": "0.0.0",
       "dependencies": {
-        "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.0.5",
+        "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.1.0",
         "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.4.0",
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.12",
@@ -18,7 +18,6 @@
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-xml": "^6.1.0",
         "@fortawesome/fontawesome-free": "^7.3.1",
-        "@rollup/rollup-linux-x64-gnu": "4.62.4",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
@@ -39,9 +38,8 @@
       }
     },
     "node_modules/@adafruit/ble-file-transfer-js": {
-      "name": "@adafruit/ble-file-transfer",
-      "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/adafruit/ble-file-transfer-js.git#09864e281e77310817b7cb6932f260db1b9581a0",
+      "version": "1.1.0",
+      "resolved": "git+ssh://git@github.com/adafruit/ble-file-transfer-js.git#cfdbef2902a0db559e03b6253123d0f9adf3cf4e",
       "license": "MIT"
     },
     "node_modules/@adafruit/circuitpython-repl-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vite-plugin-mkcert": "^2.1.0"
   },
   "dependencies": {
-    "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.0.5",
+    "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.1.0",
     "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.4.0",
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-html": "^6.4.12",


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The BLE connect flow had several waits with no upper bound, so a failure that should have been reported instead left the editor sitting there indefinitely. This does not make the underlying failures go away — most are host-side and not ours to fix — it makes them report instead of hang.

## What was unbounded

**Waiting for an advertisement before connecting.** `connectToBluetoothDevice()` armed `watchAdvertisements()` and only called `gatt.connect()` from the `advertisementreceived` handler. That event is never delivered on Linux — Chromium's BlueZ backend gates it on an `EIR` D-Bus property that exists only in the ChromeOS fork, Web Bluetooth on Linux is officially ["partially implemented and not supported"](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md), and `watchAdvertisements()` is ["No longer pursuing"](https://chromestatus.com/feature/5180688812736512). So on Linux the connect was never attempted at all, which is the "device chooser works, nothing happens afterwards" symptom. There is now a bounded wait, and that timer is what drives the connect on Linux.

**`gatt.connect()` itself.** Chrome bounds this at roughly 41 s on Linux normally, but not while a `watchAdvertisements()` watch is armed — in that state the promise simply never settles. It is now raced against a timer and cancelled with `gatt.disconnect()`, which [Chrome has honoured as a cancel since M140](https://chromium-review.googlesource.com/c/chromium/src/+/6798921).

**The same call in `_attemptSilentReconnect()`.** Easy to miss and arguably worse, since CircuitPython autoreloads after every mutating file operation, so that reconnect ladder runs after every save. An unbounded connect there stalls the ladder, and the mutating op waits on it through `awaitPostOpReconnect()`, so a save spins with no way out.

**A file read on a dead link.** `readFile()` and `listDir()` could return a promise nobody can settle: the library installed its reject handler after writing the request, so a write that failed on a dead link had no reject to call, and `checkConnection()` swallowed its own failure rather than rethrowing, letting the read proceed anyway. Both are fixed upstream, in [adafruit/ble-file-transfer-js#13](https://github.com/adafruit/ble-file-transfer-js/pull/13) and [#14](https://github.com/adafruit/ble-file-transfer-js/pull/14), released as [1.1.0](https://github.com/adafruit/ble-file-transfer-js/releases/tag/1.1.0) — which also closes [#11](https://github.com/adafruit/ble-file-transfer-js/issues/11) and [#12](https://github.com/adafruit/ble-file-transfer-js/issues/12). This PR bumps the pin from `1.0.5` to `1.1.0` and takes the fix instead of working around it: a read on a dead link rejects because `checkConnection()` now rethrows, and a link that drops mid-read rejects because the response promise is installed before the request goes out. The device-info dialogs report the rejection instead of showing a blank dialog. An earlier version of this PR carried its own liveness guard in `js/common/ble-file-transfer.js` for the same symptom; with `1.1.0` pinned it is redundant and has been removed.

## Two smaller fixes

The advertisement watch is aborted **before** `gatt.connect()` rather than after. The reason is Chrome's per-device `watchAdvertisements()` quota (#410) — leaving losers armed piles up against it. An earlier version of this PR justified the same change by claiming that connecting while a BlueZ discovery session is active fails on Linux; that was withdrawn. The failures behind it were a faulty host controller, a MediaTek MT7920 that goes 0/40 while WiFi scans and 40/40 with the radio quiet, and the same board connects 20/20 on an Intel AX210 with a watch armed or not. The code comments record what survived.

The "Looking for …" status no longer names a device when several are being raced. Both reconnect paths loop over every permitted device, so the name shown was whichever was last in `getDevices()` order, not the one that would connect.

## Testing

Feather nRF52840 Express, Metro ESP32-S3 and Circuit Playground Bluefruit; CircuitPython 10.3.0-alpha.4; Chrome 151 on Linux (Intel AX210) and macOS.

Linux connect, serial and file write were exercised repeatedly over two days, including the bounded advertisement wait and its status message, which is what makes a Linux connect complete at all — the deployed editor still hangs on the connect dialog there. A failed connect now reports an actionable error and re-enables the button. The "Current Device Info" spinner no longer hangs when the link is down — it reports the failure. The bounded silent reconnect is the least exercised of these.

The `1.1.0` bump was re-tested on a Feather nRF52840 Express with the local read guard removed: reading device info, listing an empty directory ([ble-file-transfer-js#11](https://github.com/adafruit/ble-file-transfer-js/issues/11)), listing a 60-entry directory with varied name lengths ([#12](https://github.com/adafruit/ble-file-transfer-js/issues/12)), and saving `code.py` all work. With the board reset out from under a live connection, Current Device Info reports "Could not read device information. The connection to the device was lost." rather than spinning, as expected.

One known gap in the ordering change: `abort()` returns synchronously in page JS but the resulting `StopDiscovery` reaches BlueZ asynchronously in the browser process, so `gatt.connect()` may still fire while the kernel is scanning. Measurement says this does not matter — the kernel disables scanning about 1.5 ms before every create-connection regardless of what BlueZ believes.

## Context

Chrome registers no usable BlueZ pairing agent, so on Linux the board must be paired from the desktop's Bluetooth settings before the editor can use File Transfer. That is not something this PR can fix; there is detail in [adafruit/circuitpython#11178](https://github.com/adafruit/circuitpython/pull/11178).

Separate from this PR: #545 fixes Save As silently corrupting files.


