### PR TITLE
Update ble-file-transfer-js to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-editor",
       "version": "0.0.0",
       "dependencies": {
-        "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.1.0",
+        "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.2.0",
         "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.4.0",
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.12",
@@ -38,8 +38,8 @@
       }
     },
     "node_modules/@adafruit/ble-file-transfer-js": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/adafruit/ble-file-transfer-js.git#cfdbef2902a0db559e03b6253123d0f9adf3cf4e",
+      "version": "1.2.0",
+      "resolved": "git+ssh://git@github.com/adafruit/ble-file-transfer-js.git#c8603567676638d143cbdb9deba97fe56006d1fc",
       "license": "MIT"
     },
     "node_modules/@adafruit/circuitpython-repl-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vite-plugin-mkcert": "^2.1.0"
   },
   "dependencies": {
-    "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.1.0",
+    "@adafruit/ble-file-transfer-js": "adafruit/ble-file-transfer-js#1.2.0",
     "@adafruit/circuitpython-repl-js": "adafruit/circuitpython-repl-js#3.4.0",
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-html": "^6.4.12",


### PR DESCRIPTION
Claude found the underlying bugs and wrote the library fixes.

Brings in [ble-file-transfer-js 1.2.0](https://github.com/adafruit/ble-file-transfer-js/releases/tag/1.2.0) ([adafruit/ble-file-transfer-js#15](https://github.com/adafruit/ble-file-transfer-js/pull/15)):

- Reads the transfer characteristic before subscribing, so pairing is triggered reliably. This makes espressif boards pair at all on firmware before [adafruit/circuitpython#11236](https://github.com/adafruit/circuitpython/pull/11236), and avoids doubled responses on Windows.
- Stops notifications before starting them, so reconnecting to a bonded board works. With 1.1.0, a Disconnect followed by a Connect hangs at "Current Device Info".
- Doubled or malformed responses are reported as errors instead of hanging a transfer forever.

#### Testing

Tested this library version on a Feather nRF52840 and a Metro ESP32-S3 from Chrome on Linux and on Windows 11, including first pairing and bonded reconnect on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
