### PR TITLE
fix loading code file with '>>>' string

### DIFF
--- a/js/common/repl-file-transfer.js
+++ b/js/common/repl-file-transfer.js
@@ -31,14 +31,15 @@ class FileTransferClient {
 
     async readFile(path, raw = false) {
         await this._checkConnection();
-        let contents = await this._fileops.readFile(path, raw);
+        let contents = await this._fileops.readFile(path, true);
         if (contents === null) {
             return raw ? null : "";
         }
         if (raw) {
             return contents;
         }
-        return contents.replaceAll("\r\n", "\n");
+        let text = await contents.text();
+        return text.replaceAll("\r\n", "\n");
     }
 
     async writeFile(path, offset, contents, modificationTime, raw = false) {


### PR DESCRIPTION
This fixes an issue that causes opening a file to fail if the file contains ">>>" in a string. I believe that some part of the logic is getting that confused for the REPL prompt even if it is in a string literal. 

Fixed by transferring the contents of the file in base64 instead of raw.

Thested successfully on a ESP32-C6 with by opening a file that contains `print("hello >>> world")`